### PR TITLE
fix: use new workspace reload command

### DIFF
--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -180,9 +180,7 @@ M.start = function()
     if config.tools.reload_workspace_from_cargo_toml then
       vim.api.nvim_create_autocmd('BufWritePost', {
         pattern = '*/Cargo.toml',
-        callback = function()
-          vim.cmd.RustReloadWorkspace()
-        end,
+        command = 'silent! RustLsp reloadWorkspace',
         group = augroup,
       })
     end


### PR DESCRIPTION
<!-- markdownlint-disable -->
###### Description of changes
There is an error when saving `Cargo.toml`. The plugin tries to call a non-existent command.
```
"Cargo.toml" 19L, 599B written
Error detected while processing BufWritePost Autocommands for "*/Cargo.toml":
Error executing lua callback: /home/eero/repos/rustaceanvim/lua/rustaceanvim/lsp.lua:184: Command not found: RustReloadWorkspace
stack traceback:
        [C]: in function 'RustReloadWorkspace'
        /home/eero/repos/rustaceanvim/lua/rustaceanvim/lsp.lua:184: in function </home/eero/repos/rustaceanvim/lua/rustaceanvim/lsp.lua:183> 
```

I changed the command to the current one. I first tried to call the lua function directly, but it prompted to press enter, so I opted for calling it with a vim command and `silent!`. Maybe you have a better way of achieving this, but this works.

###### Things done

- [x] Tested, as applicable:
  - [x] Manually
  - [ ] Added `busted` specs
- [x] Fits [CONTRIBUTING.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CONTRIBUTING.md)
