### PR TITLE
feat(dap): support dynamically compiled executable

### DIFF
--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -88,7 +88,9 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 
 ---@class RustaceanDapOpts
 ---@field adapter? DapExecutableConfig | DapServerConfig | disable | fun():(DapExecutableConfig | DapServerConfig | disable) Defaults to a `DapServerConfig` if `codelldb` is detected, and to a `DapExecutableConfig` if `lldb` is detected. Set to `false` to disable.
----@field auto_generate_source_map fun():boolean | boolean Whether to auto-generate a source map for the standard library.
+---@field add_dynamic_library_paths? boolean | fun():boolean Accommodate dynamically-linked targets by passing library paths to lldb. Default: `true`.
+---@field auto_generate_source_map? fun():boolean | boolean Whether to auto-generate a source map for the standard library.
+---@field load_rust_types? fun():boolean | boolean Whether to get Rust types via initCommands (rustlib/etc/lldb_commands). Default: `true`.
 
 ---@alias disable false
 

--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -160,16 +160,19 @@ local function add_dynamic_library_paths(workspace_root)
     local sep = ':'
     local win_sep = ';'
     if shell.is_windows() then
-      table.insert(environment, 'PATH=' .. rustc_target_path .. win_sep .. target_path .. win_sep .. '%PATH%')
+      local path = os.getenv('PATH') or ''
+      table.insert(environment, 'PATH=' .. rustc_target_path .. win_sep .. target_path .. win_sep .. path)
     elseif shell.is_macos() then
+      local dkld_library_path = os.getenv('DKLD_LIBRARY_PATH') or ''
       table.insert(
         environment,
-        'DKLD_LIBRARY_PATH=' .. rustc_target_path .. sep .. target_path .. sep .. '$DYLD_LIBRARY_PATH'
+        'DKLD_LIBRARY_PATH=' .. rustc_target_path .. sep .. target_path .. sep .. dkld_library_path
       )
     else
+      local ld_library_path = os.getenv('LD_LIBRARY_PATH') or ''
       table.insert(
         environment,
-        'LD_LIBRARY_PATH=' .. rustc_target_path .. sep .. target_path .. sep .. '$LD_LIBRARY_PATH'
+        'LD_LIBRARY_PATH=' .. rustc_target_path .. sep .. target_path .. sep .. ld_library_path
       )
     end
   end)

--- a/lua/rustaceanvim/shell.lua
+++ b/lua/rustaceanvim/shell.lua
@@ -1,9 +1,14 @@
 local M = {}
 
 ---@return boolean
-local function is_windows()
+function M.is_windows()
   local sysname = vim.loop.os_uname().sysname
   return sysname == 'Windows' or sysname == 'Windows_NT'
+end
+
+---@return boolean
+function M.is_macos()
+  return vim.loop.os_uname().sysname == 'Darwin'
 end
 
 ---@return boolean
@@ -20,7 +25,7 @@ end
 ---@param commands string[]
 ---@return string
 function M.chain_commands(commands)
-  local separator = is_windows() and ' | ' or is_nushell() and ';' or ' && '
+  local separator = M.is_windows() and ' | ' or is_nushell() and ';' or ' && '
   local ret = ''
 
   for i, value in ipairs(commands) do


### PR DESCRIPTION
This:
- [x] configures dyanmic library paths by default (with the ability to disable)
- [x] loads Rust type information in `lldb-vscode` by default (with the ability to disable)
- [x] looks for and uses `lldb-dap` if present (on newer installations, this will replace `lldb-vscode`) ... which now that I've rebased, I see you already did!
- [x] corrects a bug with source map configuration (I think this was not being set in the final configuration?)
- [x] removes newlines that were interfering with `rustc_sysroot` path (because they came from reading stdout)
- [x] fixes a pattern matching issue that seemed to be preventing the commit hash being detected correctly

Sorry for cramming so many little bits and pieces in at once, this is basically just a "fix some of the things that were blockers for me with lldb-vscode". My main use-case was to get Bevy engine debugging working, which this does.

I'm submitting it as a WIP so you can have a quick scan and tell me if you agree with the approach, as I don't write a great deal of Lua and there are probably some wildly non-idiomatic things you can point out! I've tried to follow the overall approach of what was there before though.

I'll look at adding some tests and tidying up tomorrow.