### PR TITLE
fix(dap): add check if codelldb is nil

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -210,7 +210,7 @@ local RustaceanDefaultConfig = {
       local result = false
       local has_mason, mason_registry = pcall(require, 'mason-registry')
       local mason_has_codelldb, codelldb = has_mason and pcall(mason_registry.get_package, 'codelldb') or false, nil
-      if mason_has_codelldb then
+      if mason_has_codelldb and codelldb ~= nil then
         local mason_codelldb_path = compat.joinpath(codelldb:get_install_path(), 'extension')
         local codelldb_path = compat.joinpath(mason_codelldb_path, 'adapter', 'codelldb')
         local liblldb_path = compat.joinpath('lldb', 'lib', 'liblldb')


### PR DESCRIPTION
<!-- markdownlint-disable -->
###### Description of changes

Unsure of the situation, but my setup returns true for `mason_has_codelldb` but `nil` for `codelldb`. This change adds a clause to check if `codelldb` is `nil` in addition to `mason_has_codelldb`.

For reference, I both have codelldb installed in Mason and on my system

###### Things done

- [ ] Tested, as applicable:
  - [ ] Manually
- [ ] Updated [CHANGELOG.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CHANGELOG.md) (if applicable).
- [ ] Fits [CONTRIBUTING.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CONTRIBUTING.md)
