### PR TITLE
fix(dap): has_package -> is_installed

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -210,7 +210,7 @@ local RustaceanDefaultConfig = {
       --- @type DapExecutableConfig | DapServerConfig | disable
       local result = false
       local has_mason, mason_registry = pcall(require, 'mason-registry')
-      if has_mason and mason_registry.has_package('codelldb') then
+      if has_mason and mason_registry.is_installed('codelldb') then
         local codelldb_package = mason_registry.get_package('codelldb')
         local mason_codelldb_path = compat.joinpath(codelldb_package:get_install_path(), 'extension')
         local codelldb_path = compat.joinpath(mason_codelldb_path, 'adapter', 'codelldb')


### PR DESCRIPTION
This:
- [x] switches out `has_package` for `is_installed` when checking Mason for the presence of `codelldb`.

`has_package` is true if the package is in the Mason registry, which is not quite what we want here. This fixes an error in the case where Mason is installed, but `codelldb` is not.

Fixes #96 