### PR TITLE
complete example in setup, disable semantic highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,15 +125,16 @@ so I suggest you define them in `~/.config/nvim/after/ftplugin/rust.lua`[^1]
 Example:
 
 ```lua
-local bufnr = vim.api.nvim_get_current_buf()
-vim.keymap.set(
-  "n", 
-  "<leader>a", 
-  function()
-    vim.cmd.RustLsp('codeAction') 
-  end,
-  { silent = true, buffer = bufnr }
-)
+vim.g.rustaceanvim = {
+  server = {
+    on_attach = function(client, bufnr)
+      -- semantic highlighting is poorly supported by many themes. It also causes the colors to change after rust-analyzer ran.
+      client.server_capabilities.semanticTokensProvider = nil
+      -- Map leader a to code actions
+      vim.keymap.set( "n", "<Leader>a", function() vim.cmd.RustLsp('codeAction') end, { silent = true, buffer = bufnr })
+      end,
+  }
+}
 ```
 
 >[!NOTE]


### PR DESCRIPTION
It's a quick setup, so a complete copy paste example would be nice.

I also added `client.server_capabilities.semanticTokensProvider = nil`, which causes annoying flickering with colors after rust-analyzer loaded (wrong colors after rust-analyzer)