### PR TITLE
fix(dap): don't load `lldb_commands` when using `codelldb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if they exist, so as not to break compatibility.
   Thanks [@saying121](https://github.com/saying121)!
 
+### Fixed
+
+- DAP: Don't load `lldb_commands` when using `codelldb`.
+
 ## [3.12.2] - 2024-01-07
 
 ### Fixed

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -89,7 +89,7 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---@field configuration? DapClientConfig | disable | fun():(DapClientConfig | disable) Dap client configuration. Defaults to a function that looks for a `launch.json` file or returns a `DapExecutableConfig` that launches the `rt_lldb` adapter. Set to `false` to disable.
 ---@field add_dynamic_library_paths? boolean | fun():boolean Accommodate dynamically-linked targets by passing library paths to lldb. Default: `true`.
 ---@field auto_generate_source_map? fun():boolean | boolean Whether to auto-generate a source map for the standard library.
----@field load_rust_types? fun():boolean | boolean Whether to get Rust types via initCommands (rustlib/etc/lldb_commands). Default: `true`.
+---@field load_rust_types? fun():boolean | boolean Whether to get Rust types via initCommands (rustlib/etc/lldb_commands, lldb only). Default: `true`.
 
 ---@alias disable false
 

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -270,7 +270,12 @@ local RustaceanDefaultConfig = {
     --- Get Rust types via initCommands (rustlib/etc/lldb_commands).
     ---@type boolean | fun():boolean
     load_rust_types = function()
-      return should_enable_dap_config_value(RustaceanConfig.dap.adapter)
+      if not should_enable_dap_config_value(RustaceanConfig.dap.adapter) then
+        return false
+      end
+      local adapter = types.evaluate(RustaceanConfig.dap.adapter)
+      --- @cast adapter DapExecutableConfig | DapServerConfig | disable
+      return adapter ~= false and adapter.type == 'executable'
     end,
     --- @type DapClientConfig | disable | fun():(DapClientConfig | disable)
     configuration = function()

--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -227,7 +227,7 @@ end
 ---@param args RADebuggableArgs
 function M.start(args)
   local adapter = types.evaluate(config.dap.adapter)
-  --- @cast adapter DapExecutableConfig | DapServerConfig | boolean
+  --- @cast adapter DapExecutableConfig | DapServerConfig | disable
 
   vim.notify('Compiling a debug build for debugging. This might take some time...')
   handle_configured_options(adapter, args)


### PR DESCRIPTION
Fixes #139.

@SlayerOfTheBad if I understand your description correctly, this should fix it?
I haven't had time to test it yet...