### PR TITLE
fix(ftplugin): Properly sanitize hover actions debug command

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -29,7 +29,7 @@ end
 vim.lsp.commands['rust-analyzer.debugSingle'] = function(command)
   local overrides = require('rustaceanvim.overrides')
   local args = command.arguments[1].args
-  overrides.sanitize_command_for_debugging(args)
+  overrides.sanitize_command_for_debugging(args.cargoArgs)
   local cached_commands = require('rustaceanvim.cached_commands')
   cached_commands.set_last_debuggable(args)
   local rt_dap = require('rustaceanvim.dap')


### PR DESCRIPTION
fixes #179 by sanitizing the actual command from hover actions debug. 

I have tested this manually on my local machine. The final command when from `run` to `build` after sanitization and dap was run.