### PR TITLE
fix(lsp): focus lost after `:RustLsp codeAction` second float opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- LSP: Focus lost when secondary float opens on `:RustLsp codeAction` [[#169](https://github.com/mrcjkb/rustaceanvim/issues/169)].
+
 ## [3.17.3] - 2024-01-25
 
 ### Fixed

--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -111,6 +111,7 @@ end
 ---@param results { [number]: RACodeActionResult }
 ---@param ctx table
 local function on_code_action_results(results, ctx)
+  local cur_win = vim.api.nvim_get_current_win()
   M.state.ctx = ctx
 
   ---@type action_tuple[]
@@ -182,7 +183,10 @@ local function on_code_action_results(results, ctx)
   vim.api.nvim_buf_attach(M.state.primary.bufnr, false, {
     on_detach = function(_, _)
       M.state.primary.clear()
-      vim.schedule(M.cleanup)
+      vim.schedule(function()
+        M.cleanup()
+        pcall(vim.api.nvim_set_current_win, cur_win)
+      end)
     end,
   })
 


### PR DESCRIPTION
Fixes #169 