### PR TITLE
fix(lsp): not reuse lsp client for standalone file

### DIFF
--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -256,6 +256,15 @@ M.start = function(bufnr)
     end
   end
 
+  if not root_dir and not rust_analyzer.get_active_rustaceanvim_clients() then
+    return vim.lsp.start(lsp_start_opts, {
+      reuse_client = function()
+        return false
+      end,
+      bufnr = bufnr,
+    })
+  end
+
   return vim.lsp.start(lsp_start_opts)
 end
 


### PR DESCRIPTION
If I open first standalone rust file, all lsp function work as expected, but when I open the second file. It will reuse lsp client for this second file, it will not show completion...

Because vim.lsp.start will reuse lsp client if we start the the same root_dir (which is nil in this case)

This PR will check if root_dir == nil, we not reuse lsp client