### PR TITLE
fix(lsp): not reuse lsp client for standalone file

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -1,3 +1,9 @@
+if vim.b.did_ftplugin_rustacean then
+  return
+end
+
+vim.b.did_ftplugin_rustacean = 1
+
 ---@type RustaceanConfig
 local config = require('rustaceanvim.config.internal')
 local types = require('rustaceanvim.types.internal')

--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -256,6 +256,15 @@ M.start = function(bufnr)
     end
   end
 
+  if not root_dir and vim.tbl_isempty(rust_analyzer.get_active_rustaceanvim_clients(bufnr)) then
+    return vim.lsp.start(lsp_start_opts, {
+      reuse_client = function()
+        return false
+      end,
+      bufnr = bufnr,
+    })
+  end
+
   return vim.lsp.start(lsp_start_opts)
 end
 


### PR DESCRIPTION
If I open first standalone rust file, all lsp function work as expected, but when I open the second file. It will reuse lsp client for this second file, so all the lsp function is not supported.

Because vim.lsp.start will reuse lsp client if we start the the same root_dir (which is nil in this case)

This PR will check if root_dir == nil, we not reuse lsp client

I also update ftplugin to prevent start function run twice.
