### PR TITLE
feat(rustc_unpretty): use rustc inspect mir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `:RustLsp rustcUnpretty` command:
+  Use `rustc -Z unpretty=mir` to inspect mir and other things,
+  and achieve an experience similar to Rust Playground.
+- Config: `tools.rustc_unpretty` arguments for `rustc`.
+
 ## [4.0.2] - 2024-01-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ vim.keymap.set(
   Achieve an experience similar to Rust Playground.
 
   NOTE: the feature need [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
-  install rust parser.
+  install rust parser and need nightly rustc.
 
   ```vimscript
   :RustLsp rustcUnpretty [hir|mir|...]

--- a/README.md
+++ b/README.md
@@ -491,6 +491,22 @@ vim.keymap.set(
   vim.cmd.RustLsp { 'view', 'hir' }
   vim.cmd.RustLsp { 'view', 'mir' }
   ```
+<details>
+  <summary>
+	<b>Rustc Unpretty</b>
+  </summary>
+
+  Opens a buffer with a textual representation of the MIR or others things
+  of the function containing the cursor.
+  Achieve an experience similar to Rust Playground.
+
+  ```vimscript
+  :RustLsp rustcUnpretty [hir|mir|...]
+  ```
+  ```lua
+  vim.cmd.RustLsp { 'rustcUnpretty', 'hir' }
+  vim.cmd.RustLsp { 'rustcUnpretty', 'mir' }
+  ```
 </details>
 
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -500,6 +500,9 @@ vim.keymap.set(
   of the function containing the cursor.
   Achieve an experience similar to Rust Playground.
 
+  NOTE: the feature need [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+  install rust parser.
+
   ```vimscript
   :RustLsp rustcUnpretty [hir|mir|...]
   ```

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -98,6 +98,11 @@ local command_tbl = {
     require('rustaceanvim.commands.fly_check')(cmd)
   end,
   rustcUnpretty = function(args)
+    local err_msg = table.concat(require('rustaceanvim.commands.rustc_unpretty').available_unpretty, ' | ')
+    if not args or #args == 0 then
+      vim.notify('Expected argument list: ' .. err_msg, vim.log.levels.ERROR)
+      return
+    end
     local arg = args[1]:lower()
     local available = false
     for _, value in ipairs(require('rustaceanvim.commands.rustc_unpretty').available_unpretty) do
@@ -106,8 +111,7 @@ local command_tbl = {
         break
       end
     end
-    if not available or not args or #args == 0 then
-      local err_msg = table.concat(require('rustaceanvim.commands.rustc_unpretty').available_unpretty, ' | ')
+    if not available then
       vim.notify('Expected argument list: ' .. err_msg, vim.log.levels.ERROR)
       return
     end

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -97,6 +97,23 @@ local command_tbl = {
     local cmd = args[1] or 'run'
     require('rustaceanvim.commands.fly_check')(cmd)
   end,
+  rustcUnpretty = function(args)
+    local arg = args[1]:lower()
+    local available = false
+    for _, value in ipairs(require('rustaceanvim.commands.rustc_unpretty').available_unpretty) do
+      if value == arg then
+        available = true
+        break
+      end
+    end
+    if not available or not args or #args == 0 then
+      local err_msg = table.concat(require('rustaceanvim.commands.rustc_unpretty').available_unpretty, ' | ')
+      vim.notify('Expected argument list: ' .. err_msg, vim.log.levels.ERROR)
+      return
+    end
+
+    require('rustaceanvim.commands.rustc_unpretty').rustc_unpretty(arg)
+  end,
   view = function(args)
     if not args or #args == 0 then
       vim.notify("Expected argument: 'mir' or 'hir'", vim.log.levels.ERROR)
@@ -165,6 +182,9 @@ function M.create_rust_lsp_command()
       end
       if cmdline:match(match_start .. '%sview' .. subcmd_match) then
         return { 'mir', 'hir' }
+      end
+      if cmdline:match(match_start .. '%srustcUnpretty' .. subcmd_match) then
+        return require('rustaceanvim.commands.rustc_unpretty').available_unpretty
       end
       if cmdline:match(match_start .. '%s+%w*$') then
         return vim.tbl_filter(function(command)

--- a/lua/rustaceanvim/commands/rustc_unpretty.lua
+++ b/lua/rustaceanvim/commands/rustc_unpretty.lua
@@ -31,11 +31,11 @@ M.available_unpretty = {
 ---@type integer | nil
 local latest_buf_id = nil
 
--- Get a compatible vim range (1 index based) from a TS node range.
---
--- TS nodes start with 0 and the end col is ending exclusive.
--- They also treat a EOF/EOL char as a char ending in the first
--- col of the next row.
+---Get a compatible vim range (1 index based) from a TS node range.
+---
+---TS nodes start with 0 and the end col is ending exclusive.
+---They also treat a EOF/EOL char as a char ending in the first
+---col of the next row.
 ---comment
 ---@param range integer[]
 ---@param buf integer|nil
@@ -95,7 +95,7 @@ end
 ---@param level rustcir_level
 function M.rustc_unpretty(level)
   if #api.nvim_get_runtime_file('parser/rust.so', true) == 0 then
-    vim.notify('please install rust parser in nvim-treesitter', vim.log.levels.ERROR)
+    vim.notify("a treesitter parser for Rust is required for 'rustc unpretty'", vim.log.levels.ERROR)
     return
   end
   if vim.fn.executable(rustc) ~= 1 then
@@ -106,18 +106,18 @@ function M.rustc_unpretty(level)
   local text
 
   local cursor = api.nvim_win_get_cursor(0)
-  local pos = { cursor[1] - 1, cursor[2] }
+  local pos = { math.max(cursor[1] - 1, 0), cursor[2] }
 
   local cline = api.nvim_get_current_line()
   if not string.find(cline, 'fn%s*') then
     local temp = vim.fn.searchpos('fn ', 'bcn', vim.fn.line('w0'))
-    pos = { temp[1] - 1, temp[2] }
+    pos = { math.max(temp[1] - 1, 0), temp[2] }
   end
 
   local node = ts.get_node { pos = pos }
 
   if node == nil or node:type() ~= 'function_item' then
-    vim.notify('not found function or function is uncomplete', vim.log.levels.ERROR)
+    vim.notify('no function found or function is incomplete', vim.log.levels.ERROR)
     return
   end
 

--- a/lua/rustaceanvim/config/check.lua
+++ b/lua/rustaceanvim/config/check.lua
@@ -65,6 +65,13 @@ function M.validate(cfg)
   if not ok then
     return false, err
   end
+  local rustc_unpretty = tools.rustc_unpretty
+  ok, err = validate('tools.rustc_ir', {
+    edition = { rustc_unpretty.edition, 'string' },
+  })
+  if not ok then
+    return false, err
+  end
   ok, err = validate('tools', {
     executor = { tools.executor, { 'table', 'string' } },
     on_initialized = { tools.on_initialized, 'function', true },

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -63,6 +63,7 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---@field float_win_config? table Options applied to floating windows. See |api-win_config|.
 ---@field create_graph? RustaceanCrateGraphConfig Options for showing the crate graph based on graphviz and the dot
 ---@field open_url? fun(url:string):nil If set, overrides how to open URLs
+---@field rustc_unpretty? table Options for `rustcUnpretty`
 
 ---@class RustaceanHoverActionsOpts
 ---@field replace_builtin_hover? boolean Whether to replace Neovim's built-in `vim.lsp.buf.hover` with hover actions. Default: `true`

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -184,6 +184,12 @@ local RustaceanDefaultConfig = {
     open_url = function(url)
       require('rustaceanvim.os').open_url(url)
     end,
+    ---settings for rustc -Z unpretty
+    ---@type table
+    rustc_unpretty = {
+      ---@type string
+      edition = '2021',
+    },
   },
 
   --- all the opts to send to the LSP client


### PR DESCRIPTION
Use `rustc -Z unpretty=mir` to inspect mir and other things,
and achieve an experience similar to Rust Playground.
The rust-analyzer view does not support viewing MIR for async blocks,
but rustc can do it.