### PR TITLE
fix(neotest): nested modules + position updates when switching buffers

### DIFF
--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -41,10 +41,19 @@ NeotestAdapter.root = function(file_name)
   return cargo.get_root_dir(file_name)
 end
 
+---@param name string Name of directory
+---@param rel_path string Path to directory, relative to root
+---@param root string Root directory of project
+---@return boolean
+---@diagnostic disable-next-line: unused-local
+NeotestAdapter.filter_dir = function(name, rel_path, root)
+  return rel_path ~= 'target'
+end
+
 ---@param file_path string
 ---@return boolean
 NeotestAdapter.is_test_file = function(file_path)
-  if file_path:find('target/%a+/build') or not vim.endswith(file_path, '.rs') then
+  if not vim.endswith(file_path, '.rs') then
     return false
   end
 

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -50,12 +50,12 @@ NeotestAdapter.is_test_file = function(file_path)
 
   local content = lib.files.read(file_path)
   local test_attributes = {
-    'test',
-    'rstest',
-    'rstest::rstest',
+    ['test'] = true,
+    ['rstest'] = true,
+    ['rstest::rstest'] = true,
   }
-  for _, attr in ipairs(test_attributes) do
-    if content:find('#%[' .. attr .. '%]') then
+  for attr in content:gmatch('#%[([%w_:]+)%]') do
+    if test_attributes[attr] then
       return true
     end
   end

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -53,23 +53,7 @@ end
 ---@param file_path string
 ---@return boolean
 NeotestAdapter.is_test_file = function(file_path)
-  if not vim.endswith(file_path, '.rs') then
-    return false
-  end
-
-  local content = lib.files.read(file_path)
-  local test_attributes = {
-    ['test'] = true,
-    ['rstest'] = true,
-    ['rstest::rstest'] = true,
-  }
-  for attr in content:gmatch('#%[([%w_:]+)%]') do
-    if test_attributes[attr] then
-      return true
-    end
-  end
-
-  return false
+  return vim.endswith(file_path, '.rs')
 end
 
 ---@class rustaceanvim.neotest.Position: neotest.Position

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -41,12 +41,11 @@ NeotestAdapter.root = function(file_name)
   return cargo.get_root_dir(file_name)
 end
 
----@param name string Name of directory
+-- ---@param name string Name of directory
 ---@param rel_path string Path to directory, relative to root
----@param root string Root directory of project
+-- ---@param root string Root directory of project
 ---@return boolean
----@diagnostic disable-next-line: unused-local
-NeotestAdapter.filter_dir = function(name, rel_path, root)
+NeotestAdapter.filter_dir = function(_, rel_path, _)
   return rel_path ~= 'target'
 end
 

--- a/lua/rustaceanvim/neotest/trans.lua
+++ b/lua/rustaceanvim/neotest/trans.lua
@@ -41,6 +41,13 @@ function M.runnable_to_position(file_path, runnable)
       end_col = location.targetRange['end'].character
     end
     local test_path = get_test_path(runnable)
+    -- strip the file module prefix from the name
+    if test_path then
+      local mod_name = vim.fn.fnamemodify(file_path, ':t:r')
+      if vim.startswith(test_path, mod_name .. '::') then
+        test_path = test_path:sub(#mod_name + 3, #test_path)
+      end
+    end
     ---@type rustaceanvim.neotest.Position
     local pos = {
       id = M.get_position_id(file_path, runnable),


### PR DESCRIPTION
This PR fixes calculating positions for nested test modules. 

I've removed the `dir` position as well as that was restricting neotest to a single file rather than the project directory, and was also preventing positions being updated when changing buffers.

I also had to add some naive matching logic to `is_test_file` as without the overriden `dir` position neotest will show all `.rs` files in the project directory, even if they contain no tests.

#### Before
<img src="https://github.com/mrcjkb/rustaceanvim/assets/8225950/ae6c5add-aab0-48d7-a22f-ed6a7dd1f32a" width="50%" />

#### After
<img src="https://github.com/mrcjkb/rustaceanvim/assets/8225950/8afe8bf5-4456-424f-8995-0952317cd069" width="50%" />
