### PR TITLE
fix(lsp,neotest): normalize file before root_dir comparison 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Windows: Normalize file actions when comparing to root dir [#245]
+
 ## [4.7.5] - 2024-02-20
 
 ### Fixed

--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -6,6 +6,7 @@ local types = require('rustaceanvim.types.internal')
 local rust_analyzer = require('rustaceanvim.rust_analyzer')
 local server_status = require('rustaceanvim.server_status')
 local cargo = require('rustaceanvim.cargo')
+local os = require('rustaceanvim.os')
 
 local function override_apply_text_edits()
   local old_func = vim.lsp.util.apply_text_edits
@@ -34,18 +35,6 @@ local function is_in_workspace(client, root_dir)
   return false
 end
 
----Normalize path for Windows, which is case insensitive
----@param path string
----@return string normalize_path
-local function normalize_path(path)
-  if require('rustaceanvim.shell').is_windows() then
-    local has_windows_drive_letter = path:match('^%a:')
-    if has_windows_drive_letter then
-      return path:sub(1, 1):lower() .. path:sub(2)
-    end
-  end
-  return path
-end
 
 ---@class LspStartConfig: RustaceanLspClientConfig
 ---@field root_dir string | nil
@@ -69,7 +58,7 @@ M.start = function(bufnr)
   ---@type LspStartConfig
   local lsp_start_config = vim.tbl_deep_extend('force', {}, client_config)
   local root_dir = cargo.get_root_dir(vim.api.nvim_buf_get_name(bufnr))
-  root_dir = root_dir and normalize_path(root_dir)
+  root_dir = root_dir and os.normalize_path(root_dir)
   lsp_start_config.root_dir = root_dir
   if not root_dir then
     --- No project root found. Start in detached/standalone mode.

--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -35,7 +35,6 @@ local function is_in_workspace(client, root_dir)
   return false
 end
 
-
 ---@class LspStartConfig: RustaceanLspClientConfig
 ---@field root_dir string | nil
 ---@field init_options? table

--- a/lua/rustaceanvim/os.lua
+++ b/lua/rustaceanvim/os.lua
@@ -33,4 +33,17 @@ function os.open_url(url)
   end
 end
 
+---Normalize path for Windows, which is case insensitive
+---@param path string
+---@return string normalize_path
+function os.normalize_path(path)
+  if require('rustaceanvim.shell').is_windows() then
+    local has_windows_drive_letter = path:match('^%a:')
+    if has_windows_drive_letter then
+      return path:sub(1, 1):lower() .. path:sub(2)
+    end
+  end
+  return path
+end
+
 return os

--- a/lua/rustaceanvim/os.lua
+++ b/lua/rustaceanvim/os.lua
@@ -38,10 +38,7 @@ end
 ---@return string normalize_path
 function os.normalize_path(path)
   if require('rustaceanvim.shell').is_windows() then
-    local has_windows_drive_letter = path:match('^%a:')
-    if has_windows_drive_letter then
-      return path:sub(1, 1):lower() .. path:sub(2)
-    end
+    return path:lower()
   end
   return path
 end

--- a/lua/rustaceanvim/rust_analyzer.lua
+++ b/lua/rustaceanvim/rust_analyzer.lua
@@ -1,6 +1,7 @@
 ---@mod rustaceanvim.rust_analyzer Functions for interacting with rust-analyzer
 
 local compat = require('rustaceanvim.compat')
+local os = require('rustaceanvim.os')
 
 ---@class RustAnalyzerClientAdapter
 local M = {}
@@ -74,7 +75,7 @@ M.file_request = function(file_path, method, params, handler)
   local client_found = false
   for _, client in ipairs(M.get_active_rustaceanvim_clients(nil, { method = method })) do
     local root_dir = client.config.root_dir
-    if root_dir and vim.startswith(file_path, root_dir) then
+    if root_dir and vim.startswith(os.normalize_path(file_path), root_dir) then
       local bufnr = find_buffer_by_name(file_path)
       if not params then
         params = {


### PR DESCRIPTION
In PR https://github.com/mrcjkb/rustaceanvim/pull/152, rustacenavim begin storing the `root_dir` with a normalized disk drive format to avoid spawning multiple rust-analyzers while navigating files.

This change caused an unintend regression on the neotest integration, as
'vim.startswith' will not match the passed in `path_files`.
https://github.com/mrcjkb/rustaceanvim/blob/4987d4159df2f80eb1deda1793ad54082d8ba454/lua/rustaceanvim/rust_analyzer.lua#L77


In summary, neotest would send the following:

```
:Neotest run file
-- -> file_path: C:\Users\me\repos\project\src\lib.rs
-- -> root_dir: c:\Users\me\projects\src\lib.rs
-- -> vim.startswith(file_path, root_dir) -- false
No tests found!
```

This commit changes the `rust_analyzer` function to ensure we use the normalized file path when performing the root_dir comparison, so we can find runnables from Neotest


---

### Review Checklist
  * [x]  Pull request title has the appropriate conventional commit prefix.
If applicable:
  * [x]  Tested
    * [ ]  Tests have been added.
    * [x]  Tested manually (Steps to reproduce in PR description).
  * [ ]  Updated documentation.
  * [x]  Updated [CHANGELOG.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CHANGELOG.md)

