### PR TITLE
fix(testables): Prevent using nextest for doctests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Testables: Run doctests when cargo-nextest is present
+
 ## [4.7.5] - 2024-02-20
 
 ### Fixed

--- a/lua/rustaceanvim/runnables.lua
+++ b/lua/rustaceanvim/runnables.lua
@@ -74,7 +74,7 @@ function M.get_command(runnable)
   ret = vim.list_extend(ret, args.cargoExtraArgs or {})
   table.insert(ret, '--')
   ret = vim.list_extend(ret, args.executableArgs or {})
-  if config.tools.enable_nextest then
+  if config.tools.enable_nextest and not vim.startswith(runnable.label, "doctest") then
     ret = overrides.try_nextest_transform(ret)
   end
 

--- a/lua/rustaceanvim/runnables.lua
+++ b/lua/rustaceanvim/runnables.lua
@@ -74,7 +74,7 @@ function M.get_command(runnable)
   ret = vim.list_extend(ret, args.cargoExtraArgs or {})
   table.insert(ret, '--')
   ret = vim.list_extend(ret, args.executableArgs or {})
-  if config.tools.enable_nextest and not vim.startswith(runnable.label, "doctest") then
+  if config.tools.enable_nextest and not vim.startswith(runnable.label, 'doctest') then
     ret = overrides.try_nextest_transform(ret)
   end
 


### PR DESCRIPTION
When `cargo-nextest` is detected, it becomes the executable to trigger `testable` runnables.

Unfortunally, `nextest` does not support doc tests. This causes the doctest runnables to fail when the binary is available on the path.

This commit prevents the use of 'nextest' for 'doctest' runnables, falling back to the `cargo test --doc` executable in this case.

This way, we can do `:RustLsp testables` and run both `#[tests]` and `doctests` properly.

---

### Review Checklist
  * [x]  Pull request title has the appropriate conventional commit prefix.
If applicable:
  * [ ]  Tested
    * [ ]  Tests have been added.
    * [x]  Tested manually (Steps to reproduce in PR description).
  * [ ]  Updated documentation.
  * [x]  Updated [CHANGELOG.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CHANGELOG.md)