### PR TITLE
feat(neotest): Expose doctests on Neotest summary window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Neotest: Expose doctests on `:Neotest summary` window
+
 ## [4.7.5] - 2024-02-20
 
 ### Fixed

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -191,7 +191,7 @@ NeotestAdapter.discover_positions = function(file_path)
     path = file_path,
     range = { 0, 0, max_end_row, 0 },
     -- use the shortest namespace for the file runnable
-    runnable =   #namespaces > 0 and namespaces[#namespaces].runnable or nil,
+    runnable = #namespaces > 0 and namespaces[#namespaces].runnable or nil,
   }
   table.insert(sorted_positions, 1, file_pos)
 

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -184,18 +184,16 @@ NeotestAdapter.discover_positions = function(file_path)
   end
   sort_positions(sorted_positions)
 
-  if #namespaces > 0 then
-    local file_pos = {
-      id = file_path,
-      name = vim.fn.fnamemodify(file_path, ':t'),
-      type = 'file',
-      path = file_path,
-      range = { 0, 0, max_end_row, 0 },
-      -- use the shortest namespace for the file runnable
-      runnable = namespaces[#namespaces].runnable,
-    }
-    table.insert(sorted_positions, 1, file_pos)
-  end
+  local file_pos = {
+    id = file_path,
+    name = vim.fn.fnamemodify(file_path, ':t'),
+    type = 'file',
+    path = file_path,
+    range = { 0, 0, max_end_row, 0 },
+    -- use the shortest namespace for the file runnable
+    runnable =   #namespaces > 0 and namespaces[#namespaces].runnable or nil,
+  }
+  table.insert(sorted_positions, 1, file_pos)
 
   return require('neotest.types.tree').from_list(sorted_positions, function(x)
     return x.name

--- a/lua/rustaceanvim/neotest/trans.lua
+++ b/lua/rustaceanvim/neotest/trans.lua
@@ -27,7 +27,7 @@ function M.runnable_to_position(file_path, runnable)
       type = 'dir'
     elseif vim.startswith(runnable.label, 'test-mod') then
       type = 'namespace'
-    elseif vim.startswith(runnable.label, 'test') or vim.startswith(runnable.label, "doctest") then
+    elseif vim.startswith(runnable.label, 'test') or vim.startswith(runnable.label, 'doctest') then
       type = 'test'
     else
       return

--- a/lua/rustaceanvim/neotest/trans.lua
+++ b/lua/rustaceanvim/neotest/trans.lua
@@ -27,7 +27,7 @@ function M.runnable_to_position(file_path, runnable)
       type = 'dir'
     elseif vim.startswith(runnable.label, 'test-mod') then
       type = 'namespace'
-    elseif vim.startswith(runnable.label, 'test') then
+    elseif vim.startswith(runnable.label, 'test') or vim.startswith(runnable.label, "doctest") then
       type = 'test'
     else
       return


### PR DESCRIPTION
The current neotest integration reports any 'test' runnable as a valid position, except for 'doctests'.

This commit introduces logic necessary to also expose 'doctests' as part of the summary, so it can be visualized and trigger.

It tries to approach it with the minimal changes, so exported labels follows the same name convention as test runnables, without indication they are doctests on the summary window. This can be changed if necessary.

In order for neotest to consider these items part of the tree, we must also return a 'pos' with `pos.type = 'file'`, otherwhise those test items would not have a parent, and it prevents being displayed. This is done by reporting a 'file' always, but I'm not sure what is the reason behind returning only if `#namespaces > 0`.

---

### Review Checklist
  * [x]  Pull request title has the appropriate conventional commit prefix.
If applicable:
  * [ ]  Tested
    * [ ]  Tests have been added.
    * [x]  Tested manually (Steps to reproduce in PR description).
  * [ ]  Updated documentation.
  * [x]  Updated [CHANGELOG.md](https://github.com/mrcjkb/rustaceanvim/blob/master/CHANGELOG.md)