### PR TITLE
fix: defer api calls in on_exit

### DIFF
--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -178,8 +178,11 @@ M.start = function(bufnr)
   local old_on_exit = lsp_start_config.on_exit
   lsp_start_config.on_exit = function(...)
     override_apply_text_edits()
-    commands.delete_rust_lsp_command()
-    vim.api.nvim_del_augroup_by_id(augroup)
+    -- on_exit runs in_fast_event
+    vim.schedule(function()
+      commands.delete_rust_lsp_command()
+      vim.api.nvim_del_augroup_by_id(augroup)
+    end)
     if type(old_on_exit) == 'function' then
       old_on_exit(...)
     end


### PR DESCRIPTION
Problem:
Error when stopping the server:
"E5560: nvim_del_user_command must not be called in a lua loop callback"

`on_exit` runs in `:h lua-loop-callbacks` and thus most `vim.api` functions can't be run in it.

Solution:
`vim.schedule()` the api calls.