### PR TITLE
fix(lsp/windows): path normalisation preventing lsp to work after gd to std lib

### DIFF
--- a/lua/rustaceanvim/cargo.lua
+++ b/lua/rustaceanvim/cargo.lua
@@ -1,5 +1,6 @@
 local compat = require('rustaceanvim.compat')
 local rust_analyzer = require('rustaceanvim.rust_analyzer')
+local os = require('rustaceanvim.os')
 local joinpath = compat.joinpath
 
 local cargo = {}
@@ -17,6 +18,7 @@ local function get_mb_active_client_root(file_name)
   local toolchains = joinpath(rustup_home, 'toolchains')
 
   for _, item in ipairs { toolchains, registry } do
+    item = os.normalize_path_on_windows(item)
     if file_name:sub(1, #item) == item then
       local clients = rust_analyzer.get_active_rustaceanvim_clients()
       return clients and #clients > 0 and clients[#clients].config.root_dir or nil

--- a/lua/rustaceanvim/os.lua
+++ b/lua/rustaceanvim/os.lua
@@ -45,7 +45,7 @@ end
 ---@return string normalized_path
 function os.normalize_path_on_windows(path)
   if shell.is_windows() and starts_with_windows_drive_letter(path) then
-    return path:sub(1, 1):lower() .. path:sub(2)
+    return path:sub(1, 1):lower() .. path:sub(2):gsub('/+', '\\')
   end
   return path
 end


### PR DESCRIPTION
## Issue 
Lsp does not work in a simple cargo project when you jump into standard library multiple times by using `gd` (go to definition). Basically, rustaceanvim is not able to identify the buffer path as being inside the standard library, therefore, it launches a new instance of rust-analyzer. This happens because the path of rustup home toolchains is like `C:\path\to\rustup-home/.toolchains` while the buffer path is `c:\path\to\rustup-home\.toolchains\to\std\lib`.

## Solution
Substitute all patterns `/+` with `\` and also use `os.normalize_path_on_windows` due to lowercase partition drive letter. 

I also thought of modifying the joinpath function in `compat.lua`, but it won't work with neovim 0.10.

## Settings
OS: **Windows**
Neovim: **0.9.5**
Neovim config: custom LazyVim with default rustaceanvim config