### PR TITLE
feat(lsp): add command to reload lsp settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- LSP: `RustAnalyzer reloadSettings` command to reload settings without restarting.
+
 ### Fixed
 
 - DAP: Defer automatic registration of nvim-dap configurations on LSP client init,

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -22,6 +22,7 @@ Commands:
  `:RustAnalyzer start` - Start the LSP client.
  `:RustAnalyzer stop` - Stop the LSP client.
  `:RustAnalyzer restart` - Restart the LSP client.
+ `:RustAnalyzer reloadSettings` - Reload settings for the LSP client.
 
 The `:RustLsp[!]` command is available after the LSP client has initialized.
 It accepts the following subcommands:

--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -239,7 +239,7 @@ M.reload_settings = function(bufnr)
   local clients = rust_analyzer.get_active_rustaceanvim_clients(bufnr)
   ---@cast clients lsp.Client[]
   for _, client in ipairs(clients) do
-    local settings = get_start_settings(vim.api.nvim_buf_get_name(bufnr), client.root_dir, config.server)
+    local settings = get_start_settings(vim.api.nvim_buf_get_name(bufnr), client.config.root_dir, config.server)
     client.settings = settings
     client.notify('workspace/didChangeConfiguration', {
       settings = client.settings,

--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -240,6 +240,7 @@ M.reload_settings = function(bufnr)
   ---@cast clients lsp.Client[]
   for _, client in ipairs(clients) do
     local settings = get_start_settings(vim.api.nvim_buf_get_name(bufnr), client.config.root_dir, config.server)
+    ---@diagnostic disable-next-line: inject-field
     client.settings = settings
     client.notify('workspace/didChangeConfiguration', {
       settings = client.settings,


### PR DESCRIPTION
Following the discussion we had in #286, I found out how to reload settings using `workspace/didChangeConfiguration`.

Turns out the lsp server responds by a `workspace/configuration` where the server actually pulls the new configuration, since the server can cache configuration and decides whether it needs to actually pull the config.

`nvim` handles it, but we need to set the `client.settings` table to the new configuration before sending the `workspace/didChangeConfiguration` because it seems to be the one used by nvim to send the actual config.

I added this feature as a command because it made sense to me, let me know if it does not for you.

Once again, tested the changes on https://github.com/GuillaumeLagrange/neoconf-repro and it works for me.

Cheers