### PR TITLE
docs: fix docs for hover actions subcommand

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -38,7 +38,7 @@ It accepts the following subcommands:
                          `args[]` allows you to override the executable's arguments.
  `expandMacro` - Expand macros recursively.
  `moveItem [up|down]` - Move items up or down.
- `hover [action|range]` - Hover actions, or hover over visually selected range.
+ `hover [actions|range]` - Hover actions, or hover over visually selected range.
  `explainError` - Display a hover window with explanations form the Rust error index.
  `renderDiagnostic` - Display a hover window with the rendered diagnostic,
                       as displayed during `cargo build`.

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -31,7 +31,7 @@
 ---                         `args[]` allows you to override the executable's arguments.
 --- `expandMacro` - Expand macros recursively.
 --- `moveItem [up|down]` - Move items up or down.
---- `hover [action|range]` - Hover actions, or hover over visually selected range.
+--- `hover [actions|range]` - Hover actions, or hover over visually selected range.
 --- `explainError` - Display a hover window with explanations form the Rust error index.
 --- `renderDiagnostic` - Display a hover window with the rendered diagnostic,
 ---                      as displayed during `cargo build`.


### PR DESCRIPTION
Straightforward docs fix to correctly indicate that the hover subcommand is "actions", not "action".