### PR TITLE
fix(lsp): escape character inserted before `}` on code action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Escape character inserted before `}` when applying code action
+  with `SnippetTextEdit` [[#303](https://github.com/mrcjkb/rustaceanvim/issues/303)].
+
 ## [4.18.2] - 2024-03-28
 
 ### Changed


### PR DESCRIPTION
Fixes #303 