### PR TITLE
feat(config): customisable group action icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Config: Customise group action icon with `tools.code_actions.group_icon`.
+
 ## [4.21.0] - 2024-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Config: Customise group action icon with `tools.code_actions.group_icon`.
+  Thanks [@ColdMacaroni](https://github.com/ColdMacaroni)!
 
 ## [4.21.0] - 2024-04-01
 

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -183,6 +183,7 @@ RustaceanHoverActionsOpts                            *RustaceanHoverActionsOpts*
 RustaceanCodeActionOpts                                *RustaceanCodeActionOpts*
 
     Fields: ~
+        {group_icon?}          (string)   Text appended to a group action. Default: `" ▶"`
         {ui_select_fallback?}  (boolean)  Whether to fall back to `vim.ui.select` if there are no grouped code actions. Default: `false`
 
 

--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -74,7 +74,7 @@ local function compute_width(action_tuples, is_group)
     local text = action.title
 
     if is_group and action.group then
-      text = action.group .. ' ▶'
+      text = action.group .. config.tools.code_actions.group_icon
     end
     local len = string.len(text)
     if len > width then
@@ -180,7 +180,7 @@ local function on_code_action_results(results, ctx)
   local idx = 1
   for key, value in pairs(M.state.actions.grouped) do
     value.idx = idx
-    vim.api.nvim_buf_set_lines(M.state.primary.bufnr, -1, -1, false, { key .. ' ▶' })
+    vim.api.nvim_buf_set_lines(M.state.primary.bufnr, -1, -1, false, { key .. config.tools.code_actions.group_icon })
     idx = idx + 1
   end
 

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -84,6 +84,7 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---@field replace_builtin_hover? boolean Whether to replace Neovim's built-in `vim.lsp.buf.hover` with hover actions. Default: `true`
 
 ---@class RustaceanCodeActionOpts
+---@field group_icon? string Text appended to a group action
 ---@field ui_select_fallback? boolean Whether to fall back to `vim.ui.select` if there are no grouped code actions. Default: `false`
 
 ---@alias lsp_server_health_status 'ok' | 'warning' | 'error'

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -128,6 +128,10 @@ local RustaceanDefaultConfig = {
     },
 
     code_actions = {
+      --- text appended to a group action
+      ---@type string
+      group_icon = ' ▶',
+
       --- whether to fall back to `vim.ui.select` if there are no grouped code actions
       ---@type boolean
       ui_select_fallback = false,


### PR DESCRIPTION
Adds an option to customise the group action icon like so:
```lua
vim.g.rustaceanvim = {
  tools = {
    code_actions = {
      group_icon = " ->"
    }
  }
}
```
![image](https://github.com/mrcjkb/rustaceanvim/assets/57285804/d5e4fa05-b58b-44b7-b319-32ffacda6f96)

🫡