### PR TITLE
fix(neotest): multiple `--no-run` flags added to debug command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.22.1] - 2024-04-14
+
+### Fixed
+
+- Neotest/DAP: multiple `--no-run` flags added to command when debugging
+  multiple times [[#357](https://github.com/mrcjkb/rustaceanvim/issues/357)].
+
 ## [4.22.0] - 2024-04-14
 
 ### Added

--- a/lua/rustaceanvim/overrides.lua
+++ b/lua/rustaceanvim/overrides.lua
@@ -66,7 +66,7 @@ end
 function M.sanitize_command_for_debugging(command)
   if command[1] == 'run' then
     command[1] = 'build'
-  elseif command[1] == 'test' then
+  elseif command[1] == 'test' and not vim.list_contains(command, '--no-run') then
     table.insert(command, 2, '--no-run')
   end
 end


### PR DESCRIPTION
Fixes #357 