### PR TITLE
fix(lsp): renderDiagnostics and explainError skipping valid diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- LSP: `renderDiagnostic` and `explainError` skipped diagnostics if they were in the same location
+  as other diagnostics
+- LSP: `renderDiagnostic` and `explainError` stopped searching early and defaulted to the first
+  diagnostic in the file instead of the next diagnostic after the current cursor position
+
 ## [4.22.6] - 2024-04-19
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- LSP: `renderDiagnostic` and `explainError` skipped diagnostics if they were in the same location
+- LSP: `renderDiagnostic` and `explainError` skipped diagnostics
+  if they were in the same location
   as other diagnostics
-- LSP: `renderDiagnostic` and `explainError` stopped searching early and defaulted to the first
-  diagnostic in the file instead of the next diagnostic after the current cursor position
+- LSP: `renderDiagnostic` and `explainError` stopped searching early
+  and defaulted to the first
+  diagnostic in the file,
+  instead of the next diagnostic after the current cursor position
 
 ## [4.22.6] - 2024-04-19
 

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -93,8 +93,8 @@ function M.explain_error()
     local pos = { diagnostic.lnum, diagnostic.col }
     -- check if there is an explainable error at the same location
     if not found then
-      local cursor_diagnostics = vim.tbl_filter(function(diagnostic)
-        return pos[1] == diagnostic.lnum and pos[2] == diagnostic.col
+      local cursor_diagnostics = vim.tbl_filter(function(diag)
+        return pos[1] == diag.lnum and pos[2] == diag.col
       end, diagnostics)
       if #cursor_diagnostics ~= 0 then
         diagnostic = cursor_diagnostics[1]
@@ -194,8 +194,8 @@ function M.render_diagnostic()
     local pos = { diagnostic.lnum, diagnostic.col }
     -- check if there is a rendered diagnostic at the same location
     if rendered_diagnostic == nil then
-      local cursor_diagnostics = vim.tbl_filter(function(diagnostic)
-        return pos[1] == diagnostic.lnum and pos[2] == diagnostic.col
+      local cursor_diagnostics = vim.tbl_filter(function(diag)
+        return pos[1] == diag.lnum and pos[2] == diag.col
       end, diagnostics)
       if #cursor_diagnostics ~= 0 then
         diagnostic = cursor_diagnostics[1]

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -92,7 +92,8 @@ function M.explain_error()
     found = diagnostic.code ~= nil and diagnostic.source == 'rustc'
     local pos = { diagnostic.lnum, diagnostic.col }
     pos_id = pos[1] + pos[2]
-    opts.cursor_position = pos
+    -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
+    opts.cursor_position = { pos[1] + 1, pos[2] }
     local searched_all = pos_map[pos_id] ~= nil
   until diagnostic == nil or found or searched_all
   if not found then
@@ -181,7 +182,8 @@ function M.render_diagnostic()
     rendered_diagnostic = get_rendered_diagnostic(diagnostic)
     local pos = { diagnostic.lnum, diagnostic.col }
     pos_id = pos[1] + pos[2]
-    opts.cursor_position = pos
+    -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
+    opts.cursor_position = { pos[1] + 1, pos[2] }
     local searched_all = pos_map[pos_id] ~= nil
   until diagnostic == nil or rendered_diagnostic ~= nil or searched_all
   if not rendered_diagnostic then

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -102,7 +102,7 @@ function M.explain_error()
         break
       end
     end
-    pos_id = pos[1] + pos[2]
+    pos_id = pos[1] * 1000 + pos[2]
     -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
     opts.cursor_position = { pos[1] + 1, pos[2] }
     local searched_all = pos_map[pos_id] ~= nil
@@ -203,7 +203,7 @@ function M.render_diagnostic()
         break
       end
     end
-    pos_id = pos[1] + pos[2]
+    pos_id = pos[1] * 1000 + pos[2]
     -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
     opts.cursor_position = { pos[1] + 1, pos[2] }
     local searched_all = pos_map[pos_id] ~= nil

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -91,6 +91,17 @@ function M.explain_error()
     end
     found = diagnostic.code ~= nil and diagnostic.source == 'rustc'
     local pos = { diagnostic.lnum, diagnostic.col }
+    -- check if there is an explainable error at the same location
+    if not found then
+      local cursor_diagnostics = vim.tbl_filter(function(diagnostic)
+        return pos[1] == diagnostic.lnum and pos[2] == diagnostic.col
+      end, diagnostics)
+      if #cursor_diagnostics ~= 0 then
+        diagnostic = cursor_diagnostics[1]
+        found = true
+        break
+      end
+    end
     pos_id = pos[1] + pos[2]
     -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
     opts.cursor_position = { pos[1] + 1, pos[2] }
@@ -181,6 +192,17 @@ function M.render_diagnostic()
     end
     rendered_diagnostic = get_rendered_diagnostic(diagnostic)
     local pos = { diagnostic.lnum, diagnostic.col }
+    -- check if there is a rendered diagnostic at the same location
+    if rendered_diagnostic == nil then
+      local cursor_diagnostics = vim.tbl_filter(function(diagnostic)
+        return pos[1] == diagnostic.lnum and pos[2] == diagnostic.col
+      end, diagnostics)
+      if #cursor_diagnostics ~= 0 then
+        diagnostic = cursor_diagnostics[1]
+        rendered_diagnostic = get_rendered_diagnostic(diagnostic)
+        break
+      end
+    end
     pos_id = pos[1] + pos[2]
     -- diagnostics are (0,0)-indexed but cursors are (1,0)-indexed
     opts.cursor_position = { pos[1] + 1, pos[2] }


### PR DESCRIPTION
There were a couple different issues with the search for the next valid diagnostic location, which I've separated out into their own commits.

I used stylua and luacheck directly instead of through nix (because I was too lazy to set it up :see_no_evil: ) but they seemed to be satisfied with what I had. If I've missed anything just let me know. Similarly, I had six tests fail when I ran `luarocks --local test` but the same six tests fail even without my changes so hopefully that's fine.

Thanks for all your work on this project by the way! I only recently started in rust and having the inline diagnostics show up as I work has been a huge time saver while I'm learning the ropes : )

To reproduce the issue, turn on the `clippy::shadow_unrelated` lint and try to cycle between the three lints in the following code:
```
    // A
    let bool = true;
    if bool == true { println!("hello"); } // bool_comparison lint

    // B
    let  blah = 6_i32; // <--- C (cursor on blah in this line)
    let bar = 3_i32;
    let blah = 5_i32; // shadow_unrelated lint // D
    let bar = 2_i32; // shadow_unrelated lint
```

Without these changes you should have inconsistent behaviour depending on where your cursor is (A/B/C/D) when you run `RustLsp renderDiagnostic`, sometimes going to the closest diagnostic after the current cursor position, and other times falling back to the first lint in the file (the bool_comparison one). 

With the changes you should always go to the closest diagnostic after the current cursor position, only wrapping around to the top when you are at the last lint or further.

(Note that there are two spaces between let and blah on the `C` line. This is to demonstrate the hash collisions, but you might need to disable autoformatting if you have that turned on so rustfmt doesn't switch it back to a single space.)