### PR TITLE
fix(lsp): update `inlay_hints.is_enabled` to new nightly format

### DIFF
--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -18,7 +18,7 @@ function M.handler(_, result, ctx, _)
   -- as soon as rust-analyzer has fully initialized.
   if type(vim.lsp.inlay_hint) == 'table' then
     for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
-      if vim.lsp.inlay_hint.is_enabled(bufnr) then
+      if vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }) then
         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
         vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
       end

--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -18,7 +18,7 @@ function M.handler(_, result, ctx, _)
   -- as soon as rust-analyzer has fully initialized.
   if type(vim.lsp.inlay_hint) == 'table' then
     for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
-      if vim.lsp.inlay_hint.is_enabled { bufnr = bufnr }  then
+      if vim.lsp.inlay_hint.is_enabled { bufnr = bufnr } then
         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
         vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
       end

--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -18,7 +18,7 @@ function M.handler(_, result, ctx, _)
   -- as soon as rust-analyzer has fully initialized.
   if type(vim.lsp.inlay_hint) == 'table' then
     for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
-      if vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }) then
+      if vim.lsp.inlay_hint.is_enabled { bufnr = bufnr }  then
         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
         vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
       end


### PR DESCRIPTION
Hi! Thanks for such a great plugin.

Neovim has changed the parameters of the `is_enabled` now it takes a filter similar to a change they did for enabling them a few weeks ago! here's a quick fix, if it suits you!