### PR TITLE
feat(ui): add `open_split_vertical` option for splits opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Config: Open vertical splits from floating windows with `tools.float_win_config.open_split = 'vertical'`.
+
 ## [4.22.10] - 2024-05-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Config: Open vertical splits from floating windows with `tools.float_win_config.open_split = 'vertical'`.
+- Config: Open vertical splits from floating windows with
+  `tools.float_win_config.open_split = 'vertical'`.
+  Thanks [@dwtong](https://github.com/dwtong)!
 
 ## [4.22.10] - 2024-05-04
 

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -27,7 +27,8 @@ local function set_open_split_keymap(bufnr, winnr, lines)
     _window_state.latest_scratch_buf_id = vim.api.nvim_create_buf(false, true) -- not listed and scratch
 
     -- split the window to create a new buffer and set it to our window
-    ui.split(false, _window_state.latest_scratch_buf_id)
+    local vsplit = config.tools.float_win_config.open_split == 'vertical'
+    ui.split(vsplit, _window_state.latest_scratch_buf_id)
 
     -- set filetype to rust for syntax highlighting
     vim.bo[_window_state.latest_scratch_buf_id].filetype = 'rust'

--- a/lua/rustaceanvim/config/check.lua
+++ b/lua/rustaceanvim/config/check.lua
@@ -61,6 +61,7 @@ function M.validate(cfg)
     max_height = { float_win_config.max_height, 'number', true },
     max_width = { float_win_config.max_width, 'number', true },
     auto_focus = { float_win_config.auto_focus, 'boolean' },
+    open_split = { float_win_config.open_split, 'string' },
   })
   if not ok then
     return false, err

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -168,6 +168,11 @@ local RustaceanDefaultConfig = {
       --- default: false
       ---@type boolean
       auto_focus = false,
+
+      --- whether splits opened from floating preview are vertical
+      --- default: false
+      ---@type 'horizontal' | 'vertical'
+      open_split = 'horizontal',
     },
 
     --- settings for showing the crate graph based on graphviz and the dot


### PR DESCRIPTION
when opening splits from a floating window with the "Open in split" option, this will set the split to open vertically.

configure with:
```lua
vim.g.rustaceanvim = {
    tools = {
        float_win_config = {
            open_split = 'vertical',
        },
    },
}
```