### PR TITLE
fix(termopen): "<Esc>" to close buffer not silent

### DIFF
--- a/lua/rustaceanvim/executors/termopen.lua
+++ b/lua/rustaceanvim/executors/termopen.lua
@@ -27,7 +27,7 @@ local M = {
     ui.resize(false, '-5')
 
     -- close the buffer when escape is pressed :)
-    vim.api.nvim_buf_set_keymap(latest_buf_id, 'n', '<Esc>', ':q<CR>', { noremap = true })
+    vim.api.nvim_buf_set_keymap(latest_buf_id, 'n', '<Esc>', '<CMD>q<CR>', { noremap = true })
 
     -- run the command
     vim.fn.termopen(full_command)


### PR DESCRIPTION
Use ":" to enter command mode, not silent by default.
In addition to this, using `<Cmd>...<CR>` has many advantages:
https://neovim.io/doc/user/map.html#%3CCmd%3E