### PR TITLE
fix(enable_clippy): use correct rust-analyzer config key

### DIFF
--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -22,8 +22,11 @@ function server.load_rust_analyzer_settings(project_root, opts)
   local default_settings = opts.default_settings or config.server.default_settings
   local use_clippy = config.tools.enable_clippy and vim.fn.executable('cargo-clippy') == 1
   ---@diagnostic disable-next-line: undefined-field
-  if default_settings['rust-analyzer'].check == nil and use_clippy and
-      type(default_settings['rust-analyzer'].checkOnSave) ~= 'table' then
+  if
+    default_settings['rust-analyzer'].check == nil
+    and use_clippy
+    and type(default_settings['rust-analyzer'].checkOnSave) ~= 'table'
+  then
     ---@diagnostic disable-next-line: inject-field
     default_settings['rust-analyzer'].check = {
       allFeatures = true,
@@ -154,4 +157,3 @@ function server.create_client_capabilities()
 end
 
 return server
-

--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -22,15 +22,18 @@ function server.load_rust_analyzer_settings(project_root, opts)
   local default_settings = opts.default_settings or config.server.default_settings
   local use_clippy = config.tools.enable_clippy and vim.fn.executable('cargo-clippy') == 1
   ---@diagnostic disable-next-line: undefined-field
-  if default_settings['rust-analyzer'].check == nil and use_clippy then
+  if default_settings['rust-analyzer'].check == nil and use_clippy and
+      type(default_settings['rust-analyzer'].checkOnSave) ~= 'table' then
     ---@diagnostic disable-next-line: inject-field
     default_settings['rust-analyzer'].check = {
       allFeatures = true,
       command = 'clippy',
       extraArgs = { '--no-deps' },
     }
-    ---@diagnostic disable-next-line: inject-field
-    default_settings['rust-analyzer'].checkOnSave = true
+    if type(default_settings['rust-analyzer'].checkOnSave) ~= 'boolean' then
+      ---@diagnostic disable-next-line: inject-field
+      default_settings['rust-analyzer'].checkOnSave = true
+    end
   end
   if not project_root then
     return default_settings
@@ -151,3 +154,4 @@ function server.create_client_capabilities()
 end
 
 return server
+

--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -22,13 +22,15 @@ function server.load_rust_analyzer_settings(project_root, opts)
   local default_settings = opts.default_settings or config.server.default_settings
   local use_clippy = config.tools.enable_clippy and vim.fn.executable('cargo-clippy') == 1
   ---@diagnostic disable-next-line: undefined-field
-  if default_settings['rust-analyzer'].checkOnSave == nil and use_clippy then
+  if default_settings['rust-analyzer'].check == nil and use_clippy then
     ---@diagnostic disable-next-line: inject-field
-    default_settings['rust-analyzer'].checkOnSave = {
+    default_settings['rust-analyzer'].check = {
       allFeatures = true,
       command = 'clippy',
       extraArgs = { '--no-deps' },
     }
+    ---@diagnostic disable-next-line: inject-field
+    default_settings['rust-analyzer'].checkOnSave = true
   end
   if not project_root then
     return default_settings


### PR DESCRIPTION
The correct config key for a rust-analyzer check command table is `check`. `checkOnSave` is a boolean.

<https://rust-analyzer.github.io/manual.html#configuration>

There are some hints in the manual that `checkOnSave` as a table is aliased to `check` but even if it is the correct key is `check`.

This prevents incorrect config conflicts downstream.