### PR TITLE
fix: don't set deprecated `allFeatures` setting by default

### DIFF
--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -29,7 +29,6 @@ function server.load_rust_analyzer_settings(project_root, opts)
   then
     ---@diagnostic disable-next-line: inject-field
     default_settings['rust-analyzer'].check = {
-      allFeatures = true,
       command = 'clippy',
       extraArgs = { '--no-deps' },
     }

--- a/spec/56_spec.lua
+++ b/spec/56_spec.lua
@@ -6,7 +6,6 @@ describe('#56-non-regression: server.settings is table', function()
     server = {
       settings = {
         ['rust-analyzer'] = {
-          cargo = { allFeatures = true },
           checkOnSave = true,
           check = {
             enable = true,


### PR DESCRIPTION
The allFeatures  setting is disabled by RA, and deprecated for two year.

ref: https://github.com/rust-lang/rust-analyzer/issues/17371#issuecomment-2169149906