### PR TITLE
fix(dap): dynamic library path setup fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- DAP: Dynamic library path setup using nigthly rust builds
+  (stable rustc was always used due to missed cwd parameter).
+- DAP: Dynamic linking on macOS didn't work due to a typo in
+  `DYLD_LIBRARY_PATH` constant.
+
 ## [4.24.1] - 2024-06-15
 
 ### Fixed

--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -202,7 +202,7 @@ local function add_dynamic_library_paths(adapter, workspace_root)
     elseif shell.is_macos() then
       ---@diagnostic disable-next-line: missing-parameter
       environments[workspace_root] = environments[workspace_root]
-        or format_environment_variable(adapter, 'DKLD_LIBRARY_PATH', { rustc_target_path, target_path }, ':')
+        or format_environment_variable(adapter, 'DYLD_LIBRARY_PATH', { rustc_target_path, target_path }, ':')
     else
       ---@diagnostic disable-next-line: missing-parameter
       environments[workspace_root] = environments[workspace_root]

--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -188,7 +188,7 @@ local function add_dynamic_library_paths(adapter, workspace_root)
   if not workspace_root or environments[workspace_root] then
     return
   end
-  compat.system({ 'rustc', '--print', 'target-libdir' }, nil, function(sc)
+  compat.system({ 'rustc', '--print', 'target-libdir' }, { cwd = workspace_root }, function(sc)
     ---@cast sc vim.SystemCompleted
     local result = sc.stdout
     if sc.code ~= 0 or result == nil then


### PR DESCRIPTION
The PR fixes two small issues in the `add_dynamic_library_paths` method:
1. Dynamic linking didn't work on `macOS` due to a typo in the `DYLD_LIBRARY_PATH` constant.
2. Dynamic linking didn't work while using `nightly toolchain` (at least on `macOS`).

The problem was found when I tried to use `rustaceanvim` with `Cargo.toml` settings recommended for `bevy engine`: (https://bevyengine.org/learn/quick-start/getting-started/setup/).

**FYI: Unfortunately I can't test that on systems.**