### PR TITLE
docs: update current support for built-in completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -864,7 +864,8 @@ Omni completion is also available for a more traditional `vim`-like completion e
 
 For more extensible and complex autocompletion setups you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
 and a LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp).
-This plugin will automatically register the necessary client capabilities if you have `cmp-nvim-lsp` installed.
+This plugin will automatically register the necessary client capabilities
+if you have `cmp-nvim-lsp` installed.
 
 #### mason.nvim and nvim-lspconfig
 

--- a/README.md
+++ b/README.md
@@ -857,7 +857,8 @@ To enable inlay hints in Neovim < 0.10, see [this discussion](https://github.com
 
 #### How to enable auto completion?
 
-As of #ff097f2091e7a970e5b12960683b4dade5563040 Neovim has built-in completion based on the `triggerCharacters` sent by
+As of [#ff097f2091e7a970e5b12960683b4dade5563040](https://github.com/neovim/neovim/pull/27339),
+Neovim has built-in completion based on the `triggerCharacters` sent by
 language servers. Omni completion is also available for a more traditional `vim`-like completion experience.
 
 For more extensible and complex autocompletion setups you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)

--- a/README.md
+++ b/README.md
@@ -859,7 +859,8 @@ To enable inlay hints in Neovim < 0.10, see [this discussion](https://github.com
 
 As of [#ff097f2091e7a970e5b12960683b4dade5563040](https://github.com/neovim/neovim/pull/27339),
 Neovim has built-in completion based on the `triggerCharacters` sent by
-language servers. Omni completion is also available for a more traditional `vim`-like completion experience.
+language servers.
+Omni completion is also available for a more traditional `vim`-like completion experience.
 
 For more extensible and complex autocompletion setups you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
 and a LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp).

--- a/README.md
+++ b/README.md
@@ -857,17 +857,12 @@ To enable inlay hints in Neovim < 0.10, see [this discussion](https://github.com
 
 #### How to enable auto completion?
 
-Neovim *does not* have built-in support for auto-completion,
-and adding support for that is beyond the scope of this plugin.
+As of #ff097f2091e7a970e5b12960683b4dade5563040 Neovim has built-in completion based on the `triggerCharacters` sent by
+language servers. Omni completion is also available for a more traditional `vim`-like completion experience.
 
-You have a few choices for completion:
-
-- Use Neovim's built-in omni completion (see `:h omnifunc`).
-  This supports basic LSP completions, but not autocompletion.
-- For autocompletion, you need a plugin, for example [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
-  and an LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp).
-  This plugin will automatically register the necessary client capabilities
-  if you have `cmp-nvim-lsp` installed.
+For more extensible and complex autocompletion setups you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
+and a LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp).
+This plugin will automatically register the necessary client capabilities if you have `cmp-nvim-lsp` installed.
 
 #### mason.nvim and nvim-lspconfig
 


### PR DESCRIPTION
A bit of a shameless plug, but when exploring this plugin I noticed that the README says that core doesn't support autocompletion, but as of https://github.com/neovim/neovim/pull/27339 it does :)