### PR TITLE
feat(lsp): Arguments to explainError/renderDiagnostic from current line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.25.1] - 2024-06-21
-
-### Changed
-
-- Testables: Default to `termopen` test executor if not using `neotest`
+## [Unreleased]
 
 ### Added
 
@@ -18,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `explainError` and `renderDiagnostic` commands.
   No argument defaults to `cycle`, which is current base behaviour. `current`
   makes these functions only look for diagnostics in current cursor line
+
+### Fixed
+
+## [4.25.1] - 2024-06-21
+
+### Changed
+
+- Testables: Default to `termopen` test executor if not using `neotest`
+
+### Added
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- LSP: Added optional `current`/`cycle` arguments to 
+- LSP: Added optional `current`/`cycle` arguments to
   the `explainError` and `renderDiagnostic` commands.
   No argument defaults to `cycle`, which is current base behaviour. `current`
   makes these functions only look for diagnostics in current cursor line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- LSP: Added current/cycle arguments to explainError and renderDiagnostic.
+  No argument defaults to cycle which is current base behavior. 'current' option
+  makes these functions only look for diagnostics in current cursor line
+
 ### Fixed
 
 - LSP: Support completions for `RustLsp` with selection ranges.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- LSP: Added current/cycle arguments to explainError and renderDiagnostic.
-  No argument defaults to cycle which is current base behavior. 'current' option
+- LSP: Added optional `current`/`cycle` arguments to 
+  the `explainError` and `renderDiagnostic` commands.
+  No argument defaults to `cycle`, which is current base behaviour. `current`
   makes these functions only look for diagnostics in current cursor line
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -427,15 +427,21 @@ vim.keymap.set(
   over error diagnostics (if they have an error code).
   
   ```vim
-  :RustLsp explainError
+  :RustLsp explainError {cycle?|current?}
   ```
   ```lua
-  vim.cmd.RustLsp('explainError')
+  vim.cmd.RustLsp('explainError') -- default to 'cycle'
+  vim.cmd.RustLsp({ 'explainError', 'cycle' })
+  vim.cmd.RustLsp({ 'explainError', 'current' })
   ```
 
-  Like `vim.diagnostic.goto_next`, `explainError` will cycle diagnostics,
-  starting at the cursor position, until it can find a diagnostic with
-  an error code.
+  If cycle option:
+    Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
+    starting at the cursor position, until it can find a diagnostic with
+    an error code.
+  If current option
+    Searches for diagnostics only in the current cursor line
+  Defaults to 'explainError cycle', if called without an argument 
 
 ![](https://github.com/mrcjkb/rustaceanvim/assets/12857160/bac9b31c-22ca-40c4-bfd3-b8c5ba4cc49a)
 

--- a/README.md
+++ b/README.md
@@ -453,17 +453,19 @@ vim.keymap.set(
   together.
   
   ```vim
-  :RustLsp renderDiagnostic
+  :RustLsp renderDiagnostic {cycle?|current?}
   ```
   ```lua
-  vim.cmd.RustLsp('renderDiagnostic')
+  vim.cmd.RustLsp('renderDiagnostic') -- defaults to 'cycle'
+  vim.cmd.RustLsp({ 'renderDiagnostic', 'cycle' })
+  vim.cmd.RustLsp({ 'renderDiagnostic', 'current' })
   ```
 
-  If cycle option:
+  If 'cycle' option:
     Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
     starting at the cursor position, until it can find a diagnostic with
     rendered data.
-  If current option:
+  If 'current' option:
     Searches for diagnostics only in the current cursor line
   Defaults to 'renderDiagnostic cycle', if called without an argument 
 

--- a/README.md
+++ b/README.md
@@ -469,13 +469,15 @@ vim.keymap.set(
   vim.cmd.RustLsp({ 'renderDiagnostic', 'current' })
   ```
 
-  If 'cycle' option:
-    Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
-    starting at the cursor position, until it can find a diagnostic with
-    rendered data.
-  If 'current' option:
-    Searches for diagnostics only in the current cursor line
-  Defaults to 'renderDiagnostic cycle', if called without an argument 
+  - If called with `cycle` or no args:
+    Like `vim.diagnostic.goto_next`,
+    `renderDiagnostic` will cycle diagnostics,
+    starting at the cursor position,
+    until it can find a diagnostic with rendered data.
+    
+  - If called with `current`:
+    Searches for diagnostics only in the
+    current cursor line.
 
 ![](https://github.com/mrcjkb/rustaceanvim/assets/12857160/a972c6b6-c504-4c2a-8380-53451bb8c2de)
 

--- a/README.md
+++ b/README.md
@@ -459,9 +459,13 @@ vim.keymap.set(
   vim.cmd.RustLsp('renderDiagnostic')
   ```
 
-  Like `vim.diagnostic.goto_next`, `renderDiagnostic` will cycle diagnostics,
-  starting at the cursor position, until it can find a diagnostic with
-  rendered data.
+  If cycle option:
+    Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
+    starting at the cursor position, until it can find a diagnostic with
+    rendered data.
+  If current option:
+    Searches for diagnostics only in the current cursor line
+  Defaults to 'renderDiagnostic cycle', if called without an argument 
 
 ![](https://github.com/mrcjkb/rustaceanvim/assets/12857160/a972c6b6-c504-4c2a-8380-53451bb8c2de)
 

--- a/README.md
+++ b/README.md
@@ -435,13 +435,15 @@ vim.keymap.set(
   vim.cmd.RustLsp({ 'explainError', 'current' })
   ```
 
-  If cycle option:
-    Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
-    starting at the cursor position, until it can find a diagnostic with
-    an error code.
-  If current option
-    Searches for diagnostics only in the current cursor line
-  Defaults to 'explainError cycle', if called without an argument 
+  - If called with `cycle` or no args:
+    Like `vim.diagnostic.goto_next`,
+    `explainError` will cycle diagnostics,
+    starting at the cursor position,
+    until it can find a diagnostic with an error code.
+    
+  - If called with `current`:
+    Searches for diagnostics only in the
+    current cursor line.
 
 ![](https://github.com/mrcjkb/rustaceanvim/assets/12857160/bac9b31c-22ca-40c4-bfd3-b8c5ba4cc49a)
 

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -67,8 +67,8 @@ function M.explain_error()
 
   local diagnostics = vim.tbl_filter(function(diagnostic)
     return diagnostic.code ~= nil
-      and diagnostic.source == 'rustc'
-      and diagnostic.severity == vim.diagnostic.severity.ERROR
+        and diagnostic.source == 'rustc'
+        and diagnostic.severity == vim.diagnostic.severity.ERROR
   end, vim.diagnostic.get(0, {}))
   if #diagnostics == 0 then
     vim.notify('No explainable errors found.', vim.log.levels.INFO)
@@ -168,13 +168,16 @@ function M.explain_error_current_line()
   local cursor_position = vim.api.nvim_win_get_cursor(win_id)
 
   -- get matching diagnostics from current line
-  local diagnostics = vim.tbl_filter(function(diagnostic)
-    return diagnostic.code ~= nil
-      and diagnostic.source == 'rustc'
-      and diagnostic.severity == vim.diagnostic.severity.ERROR
-  end, vim.diagnostic.get(0, {
-      lnum = cursor_position[1] - 1
-    }))
+  local diagnostics = vim.tbl_filter(
+    function(diagnostic)
+      return diagnostic.code ~= nil
+          and diagnostic.source == 'rustc'
+          and diagnostic.severity == vim.diagnostic.severity.ERROR
+    end,
+    vim.diagnostic.get(0, {
+      lnum = cursor_position[1] - 1,
+    })
+  )
 
   -- no matching diagnostics on current line
   if #diagnostics == 0 then
@@ -316,11 +319,14 @@ function M.render_diagnostic_current_line()
   local cursor_position = vim.api.nvim_win_get_cursor(win_id)
 
   -- get rendered diagnostics from current line
-  local rendered_diagnostics = vim.tbl_map(function(diagnostic)
-    return get_rendered_diagnostic(diagnostic)
-  end, vim.diagnostic.get(0, {
-      lnum = cursor_position[1] - 1
-    }))
+  local rendered_diagnostics = vim.tbl_map(
+    function(diagnostic)
+      return get_rendered_diagnostic(diagnostic)
+    end,
+    vim.diagnostic.get(0, {
+      lnum = cursor_position[1] - 1,
+    })
+  )
   rendered_diagnostics = vim.tbl_filter(function(diagnostic)
     return diagnostic ~= nil
   end, rendered_diagnostics)

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -67,8 +67,8 @@ function M.explain_error()
 
   local diagnostics = vim.tbl_filter(function(diagnostic)
     return diagnostic.code ~= nil
-        and diagnostic.source == 'rustc'
-        and diagnostic.severity == vim.diagnostic.severity.ERROR
+      and diagnostic.source == 'rustc'
+      and diagnostic.severity == vim.diagnostic.severity.ERROR
   end, vim.diagnostic.get(0, {}))
   if #diagnostics == 0 then
     vim.notify('No explainable errors found.', vim.log.levels.INFO)
@@ -171,8 +171,8 @@ function M.explain_error_current_line()
   local diagnostics = vim.tbl_filter(
     function(diagnostic)
       return diagnostic.code ~= nil
-          and diagnostic.source == 'rustc'
-          and diagnostic.severity == vim.diagnostic.severity.ERROR
+        and diagnostic.source == 'rustc'
+        and diagnostic.severity == vim.diagnostic.severity.ERROR
     end,
     vim.diagnostic.get(0, {
       lnum = cursor_position[1] - 1,

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -182,14 +182,7 @@ function M.explain_error_current_line()
     return
   end
 
-  -- local opts = {
-  --   cursor_position = vim.api.nvim_win_get_cursor(win_id),
-  --   severity = vim.diagnostic.severity.ERROR,
-  --   wrap = true,
-  -- }
   local diagnostic = diagnostics[1]
-  -- local pos = { diagnostic.lnum, diagnostic.col }
-  -- opts.cursor_position = pos
 
   ---@param sc vim.SystemCompleted
   local function handler(sc)

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -60,8 +60,18 @@ local rustlsp_command_tbl = {
     end,
   },
   explainError = {
-    impl = function(_)
-      require('rustaceanvim.commands.diagnostic').explain_error()
+    impl = function(args)
+      local subcmd = args[1] or 'cycle'
+      if subcmd == 'cycle' then
+        require('rustaceanvim.commands.diagnostic').explain_error()
+      elseif subcmd == 'current' then
+        require('rustaceanvim.commands.diagnostic').explain_error_current_line()
+      else
+        vim.notify('explainError: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'", vim.log.levels.ERROR)
+      end
+    end,
+    complete = function()
+      return { 'cycle', 'current' }
     end,
   },
   renderDiagnostic = {

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -67,7 +67,10 @@ local rustlsp_command_tbl = {
       elseif subcmd == 'current' then
         require('rustaceanvim.commands.diagnostic').explain_error_current_line()
       else
-        vim.notify('explainError: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'", vim.log.levels.ERROR)
+        vim.notify(
+          'explainError: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'",
+          vim.log.levels.ERROR
+        )
       end
     end,
     complete = function()
@@ -82,7 +85,10 @@ local rustlsp_command_tbl = {
       elseif subcmd == 'current' then
         require('rustaceanvim.commands.diagnostic').render_diagnostic_current_line()
       else
-        vim.notify('renderDiagnostic: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'", vim.log.levels.ERROR)
+        vim.notify(
+          'renderDiagnostic: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'",
+          vim.log.levels.ERROR
+        )
       end
     end,
     complete = function()

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -65,8 +65,18 @@ local rustlsp_command_tbl = {
     end,
   },
   renderDiagnostic = {
-    impl = function(_)
-      require('rustaceanvim.commands.diagnostic').render_diagnostic()
+    impl = function(args)
+      local subcmd = args[1] or 'cycle'
+      if subcmd == 'cycle' then
+        require('rustaceanvim.commands.diagnostic').render_diagnostic()
+      elseif subcmd == 'current' then
+        require('rustaceanvim.commands.diagnostic').render_diagnostic_current_line()
+      else
+        vim.notify('renderDiagnostic: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'", vim.log.levels.ERROR)
+      end
+    end,
+    complete = function()
+      return { 'cycle', 'current' }
     end,
   },
   rebuildProcMacros = {

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -34,10 +34,14 @@
 --- 'expandMacro' - Expand macros recursively.
 --- 'moveItem {up|down}' - Move items up or down.
 --- 'hover {actions|range}' - Hover actions, or hover over visually selected range.
---- 'explainError' - Display a hover window with explanations form the Rust error index.
----                  Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
----                  starting at the cursor position, until it can find a diagnostic with
----                  an error code.
+--- 'explainError {cycle?|current?}' - Display a hover window with explanations form the Rust error index.
+---                  If cycle option:
+---                    Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
+---                    starting at the cursor position, until it can find a diagnostic with
+---                    an error code.
+---                  If current option
+---                    Searches for diagnostics only in the current cursor line
+---                  Defaults to 'explainError cycle', if called without an argument 
 --- 'renderDiagnostic {cycle?|current?}' - Display a hover window with the rendered diagnostic,
 ---                      as displayed during `cargo build`.
 ---                  If cycle option:

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -38,11 +38,15 @@
 ---                  Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
 ---                  starting at the cursor position, until it can find a diagnostic with
 ---                  an error code.
---- 'renderDiagnostic' - Display a hover window with the rendered diagnostic,
+--- 'renderDiagnostic {cycle?|current?}' - Display a hover window with the rendered diagnostic,
 ---                      as displayed during `cargo build`.
----                  Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
----                  starting at the cursor position, until it can find a diagnostic with
----                  rendered data.
+---                  If cycle option:
+---                    Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
+---                    starting at the cursor position, until it can find a diagnostic with
+---                    rendered data.
+---                  If current option
+---                    Searches for diagnostics only in the current cursor line
+---                  Defaults to 'renderDiagnostic cycle', if called without an argument 
 --- 'openCargo' - Open the Cargo.toml file for the current package.
 --- 'openDocs' - Open docs.rs documentation for the symbol under the cursor.
 --- 'parentModule' - Open the current module's parent module.

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -35,22 +35,24 @@
 --- 'moveItem {up|down}' - Move items up or down.
 --- 'hover {actions|range}' - Hover actions, or hover over visually selected range.
 --- 'explainError {cycle?|current?}' - Display a hover window with explanations form the Rust error index.
----                  If cycle option:
----                    Like |vim.diagnostic.goto_next|, |explainError| will cycle diagnostics,
----                    starting at the cursor position, until it can find a diagnostic with
----                    an error code.
----                  If current option
----                    Searches for diagnostics only in the current cursor line
----                  Defaults to 'explainError cycle', if called without an argument 
+---            - If called with |cycle| or no args:
+---              Like |vim.diagnostic.goto_next|,
+---              |explainError| will cycle diagnostics,
+---              starting at the cursor position,
+---              until it can find a diagnostic with an error code.
+---            - If called with |current|:
+---              Searches for diagnostics only in the
+---              current cursor line.
 --- 'renderDiagnostic {cycle?|current?}' - Display a hover window with the rendered diagnostic,
----                      as displayed during `cargo build`.
----                  If cycle option:
----                    Like |vim.diagnostic.goto_next|, |renderDiagnostic| will cycle diagnostics,
----                    starting at the cursor position, until it can find a diagnostic with
----                    rendered data.
----                  If current option
----                    Searches for diagnostics only in the current cursor line
----                  Defaults to 'renderDiagnostic cycle', if called without an argument 
+---            as displayed during |cargo build|.
+---            - If called with |cycle| or no args:
+---              Like |vim.diagnostic.goto_next|,
+---              |renderDiagnostic| will cycle diagnostics,
+---              starting at the cursor position,
+---              until it can find a diagnostic with rendered data.
+---            - If called with |current|:
+---              Searches for diagnostics only in the
+---              current cursor line.
 --- 'openCargo' - Open the Cargo.toml file for the current package.
 --- 'openDocs' - Open docs.rs documentation for the symbol under the cursor.
 --- 'parentModule' - Open the current module's parent module.


### PR DESCRIPTION
feat(lsp): explainError and renderDiagnostic command now have optional argument {cycle?|current?}. It default to cycle which is current behavior, current option makes it search for diagnostic only in the current cursor line