### PR TITLE
chore(testables): default to `termopen` test executor if not using `neotest`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.25.1] - 2024-06-21
+
+### Changed
+
+- Testables: Default to `termopen` test executor if not using `neotest`
 
 ### Fixed
 

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -67,21 +67,12 @@ local function load_dap_configuration(type)
 end
 
 ---@return RustaceanExecutor
-local function get_crate_test_executor()
-  if vim.fn.has('nvim-0.10.0') == 1 then
-    return executors.background
-  else
-    return executors.termopen
-  end
-end
-
----@return RustaceanExecutor
 local function get_test_executor()
   if package.loaded['rustaceanvim.neotest'] ~= nil then
     -- neotest has been set up with rustaceanvim as an adapter
     return executors.neotest
   end
-  return get_crate_test_executor()
+  return executors.termopen
 end
 
 ---@class RustaceanConfig
@@ -98,7 +89,7 @@ local RustaceanDefaultConfig = {
     test_executor = get_test_executor(),
 
     ---@type RustaceanExecutor
-    crate_test_executor = get_crate_test_executor(),
+    crate_test_executor = executors.termopen,
 
     ---@type string | nil
     cargo_override = nil,


### PR DESCRIPTION
The `background` one is nice, but it doesn't have a way to show log output.