### PR TITLE
feat(diagnostic): ansi code colored disagnostics in floating and spli…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- LSP: Added colored ansi code diagnotic to floating and split window.
+
 ## [5.0.0] - 2024-07-26
 
 ### BREAKING CHANGES

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -241,6 +241,7 @@ end
 
 ---@param rendered_diagnostic string
 local function render_ansi_code_diagnostic(rendered_diagnostic)
+  -- adopted from https://stackoverflow.com/questions/48948630/lua-ansi-escapes-pattern
   local lines =
     vim.split(rendered_diagnostic:gsub('[\27\155][][()#;?%d]*[A-PRZcf-ntqry=><~]', ''), '\n', { trimempty = true })
   local float_preview_lines = vim.deepcopy(lines)

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -239,39 +239,6 @@ local function get_rendered_diagnostic(diagnostic)
   end
 end
 
-local function validate_window_dimensions(float_preview_lines, user_float_win_config)
-  local float_preview_config = vim.tbl_extend('keep', user_float_win_config, {
-    focus = false,
-    focusable = true,
-    focus_id = 'ra-render-diagnostic',
-    close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
-  })
-
-  local c = vim.deepcopy(float_preview_config)
-  for _, key in ipairs { 'width', 'height', 'max_width', 'max_height' } do
-    c[key] = nil
-  end
-
-  local width, height = vim.lsp.util._make_floating_popup_size(float_preview_lines, c)
-
-  if user_float_win_config.width and user_float_win_config.width > width then
-    width = user_float_win_config.width
-  end
-  if user_float_win_config.height and user_float_win_config.height > height then
-    height = user_float_win_config.height
-  end
-  if user_float_win_config.max_width and user_float_win_config.max_width < width then
-    float_preview_config.max_width = width
-  end
-  if user_float_win_config.max_height and user_float_win_config.max_height < height then
-    float_preview_config.max_height = height
-  end
-
-  float_preview_config.height = height
-  float_preview_config.width = width
-  return float_preview_config
-end
-
 ---@param rendered_diagnostic string
 local function render_ansi_code_diagnostic(rendered_diagnostic)
   local lines =
@@ -284,7 +251,12 @@ local function render_ansi_code_diagnostic(rendered_diagnostic)
     local bufnr, winnr = vim.lsp.util.open_floating_preview(
       float_preview_lines,
       '',
-      validate_window_dimensions(float_preview_lines, config.tools.float_win_config)
+      vim.tbl_extend('keep', config.tools.float_win_config, {
+        focus = false,
+        focusable = true,
+        focus_id = 'ra-render-diagnostic',
+        close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
+      })
     )
     local autocmd_id = vim.api.nvim_create_autocmd('WinEnter', {
       callback = function(args)

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -259,31 +259,25 @@ local function render_ansi_code_diagnostic(rendered_diagnostic)
         close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
       })
     )
-    local autocmd_id = vim.api.nvim_create_autocmd('WinEnter', {
-      callback = function(args)
-        if args.buf == bufnr then
-          vim.api.nvim_feedkeys(
-            vim.api.nvim_replace_termcodes(
-              [[<c-\><c-n>]] .. '<cmd>lua vim.api.nvim_win_set_cursor(' .. winnr .. ',{1,0})<CR>',
-              true,
-              false,
-              true
-            ),
-            'n',
-            true
-          )
-        end
-      end,
-    })
-    local chanid = vim.api.nvim_open_term(bufnr, {})
-    vim.api.nvim_create_autocmd('WinClosed', {
-      once = true,
-      pattern = tostring(winnr),
+    vim.api.nvim_create_autocmd('WinEnter', {
       callback = function()
-        vim.api.nvim_del_autocmd(autocmd_id)
+        vim.api.nvim_feedkeys(
+          vim.api.nvim_replace_termcodes(
+            [[<c-\><c-n>]] .. '<cmd>lua vim.api.nvim_win_set_cursor(' .. winnr .. ',{1,0})<CR>',
+            true,
+            false,
+            true
+          ),
+          'n',
+          true
+        )
       end,
+      buffer = bufnr,
     })
+
+    local chanid = vim.api.nvim_open_term(bufnr, {})
     vim.api.nvim_chan_send(chanid, vim.trim('1. Open in split\r\n' .. '---\r\n' .. rendered_diagnostic))
+
     _window_state.float_winnr = winnr
     set_close_keymaps(bufnr)
     set_split_open_keymap(bufnr, winnr, function()

--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -82,6 +82,7 @@ local function make_rustaceanvim_capabilities()
   -- send actions with hover request
   capabilities.experimental = {
     hoverActions = true,
+    colorDiagnosticOutput = true,
     hoverRange = true,
     serverStatusNotification = true,
     snippetTextEdit = true,


### PR DESCRIPTION
close #442 
float:
<img width="936" alt="截屏2024-07-24 06 01 02" src="https://github.com/user-attachments/assets/dc4cd944-d279-47c3-b8ea-42c9839c20bc">

split:
<img width="940" alt="截屏2024-07-24 06 01 09" src="https://github.com/user-attachments/assets/88b21886-e4d9-42ca-b8ce-0f7ecb4cea78">





The idea is using nvim_open_term to let nvim render ansi code diagnostic for us, there is one problem, the window size must bigger than both of diagnostic's width and content, if not, previous lines get cleared by nvim somehow(idk why) like this image, notice the error: is missing.

<img width="447" alt="截屏2024-07-24 05 31 47" src="https://github.com/user-attachments/assets/8d08b37f-e000-4177-a835-fdc38f319675">

You can try my first commit and set width to a small number say 20.
I don't use rust often lately, hope it works well😸 

