### PR TITLE
fix(diagnostic): pass correct flycheck arg for clear/cancel

### DIFF
--- a/lua/rustaceanvim/commands/fly_check.lua
+++ b/lua/rustaceanvim/commands/fly_check.lua
@@ -6,7 +6,7 @@ local rl = require('rustaceanvim.rust_analyzer')
 
 ---@param cmd rustaceanvim.flyCheckCommand
 function M.fly_check(cmd)
-  local params = cmd == 'run' and vim.lsp.util.make_text_document_params() or {}
+  local params = cmd == 'run' and vim.lsp.util.make_text_document_params() or nil
   rl.notify('rust-analyzer/' .. cmd .. 'Flycheck', params)
 end
 


### PR DESCRIPTION
I tested this and it fixes https://github.com/mrcjkb/rustaceanvim/issues/465, the clear/cancel subcommands for flyCheck command work.