### PR TITLE
fix(lsp): copy settings to init_options when starting the server to match VSCode

### DIFF
--- a/lua/rustaceanvim/lsp.lua
+++ b/lua/rustaceanvim/lsp.lua
@@ -127,6 +127,16 @@ M.start = function(bufnr)
   lsp_start_config.settings = get_start_settings(bufname, root_dir, client_config)
   configure_file_watcher(lsp_start_config)
 
+  -- rust-analyzer treats settings in initializationOptions specially -- in particular, workspace_discoverConfig
+  -- so copy them to init_options (the vim name)
+  -- so they end up in initializationOptions (the LSP name)
+  -- ... and initialization_options (the rust name) in rust-analyzer's main.rs
+  lsp_start_config.init_options = vim.tbl_deep_extend(
+    'force',
+    lsp_start_config.init_options or {},
+    vim.tbl_get(lsp_start_config.settings, 'rust-analyzer')
+  )
+
   -- Check if a client is already running and add the workspace folder if necessary.
   for _, client in pairs(rust_analyzer.get_active_rustaceanvim_clients()) do
     if root_dir and not is_in_workspace(client, root_dir) then


### PR DESCRIPTION
This is a prerequisite to using `workspace_discoverConfig` at all, since if it isn't present in the initialization RPC, then rust-analyzer just discovers a cargo project and never looks at workspace_discoverConfig ever again. The discoverConfig stuff is pretty unstable but this at least gets things going.

Note that VSCode does it this way as well. I think at this point we may be sending too many didChangeConfiguration RPCs, but at least stuff works!

Example config -- using `rust-project` from the [buck2](https://github.com/facebook/buck2) project

(Put this in a `rust-analyzer.json` file for rustaceanvim to find. The `rust-analyzer.toml` support in R-A itself is still incapable of reading the file at startup... :/)

```json
{
  "rust-analyzer.workspace.discoverConfig": {
    "command": [
      "rust-project",
      "develop-json",
      "--use-clippy",
      "false",
      "{arg}"
    ],
    "progressLabel": "buck2/rust-project",
    "filesToWatch": ["BUCK", "BUCK.v2"]
  }
}
```