### PR TITLE
feat(dap): use integrated terminal for lldb-dap by default

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -42,6 +42,9 @@ local function load_dap_configuration(type)
     request = 'launch',
     stopOnEntry = false,
   }
+  if type == 'lldb' then
+    dap_config.runInTerminal = true
+  end
   ---@diagnostic disable-next-line: different-requires
   local dap = require('dap')
   -- Load configurations from a `launch.json`.


### PR DESCRIPTION
## Description

`lldb-dap` has supported integrated terminal and we can use this feature by default which is consistent with the behavior of `codelldb`.

## Environment
OS: macOS 14.6.1
Arch: arm64
LLVM: 18.1.8

## Snapshot

<img width="1512" alt="Snipaste_2024-09-05_21-05-21" src="https://github.com/user-attachments/assets/4ac879c8-7e35-4f9f-b907-d56b58ed304a">
