### PR TITLE
feat(lsp): support ddc_source_lsp server capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Adds support for ddc_source_lsp client capabilities for auto import.
+
 ## [5.5.0] - 2024-09-16
 
 ### Changed
 
 - Deprecate `rust-analyzer.json` in favour of `.vscode/settings.json`
   or `:h exrc`.
-
-### Added
-- Adds support for ddc_source_lsp client capabilities for auto import.
 
 ## [5.4.2] - 2024-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecate `rust-analyzer.json` in favour of `.vscode/settings.json`
   or `:h exrc`.
+- Adds support for ddc_source_lsp client capabilities for auto import.
 
 ## [5.4.2] - 2024-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecate `rust-analyzer.json` in favour of `.vscode/settings.json`
   or `:h exrc`.
+
+### Added
 - Adds support for ddc_source_lsp client capabilities for auto import.
 
 ## [5.4.2] - 2024-09-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Deprecate `rust-analyzer.json` in favour of `.vscode/settings.json`
+  or `:h exrc`.
+
 ## [5.4.2] - 2024-09-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -799,30 +799,15 @@ end
 
 ### How to dynamically load different `rust-analyzer` settings per project
 
-By default, this plugin will look for a `rust-analyzer.json`[^2]
-file in the project root directory, and attempt to load it.
+By default, this plugin will look for a `.vscode/settings.json`[^2]
+file and attempt to load it.
 If the file does not exist, or it can't be decoded,
 the `server.default_settings` will be used.
 
 [^2]: See [this example](https://github.com/rust-analyzer/rust-project.json-example/blob/master/.vscode/settings.json)
       and the rust-analyzer [configuration manual](https://rust-analyzer.github.io/manual.html#configuration).
 
-You can change this behaviour with the `server.settings` config:
-
-```lua
-vim.g.rustaceanvim = {
-  -- ...
-  server = {
-    ---@param project_root string Path to the project root
-    settings = function(project_root)
-      local ra = require('rustaceanvim.config.server')
-      return ra.load_rust_analyzer_settings(project_root, {
-        settings_file_pattern = 'rust-analyzer.json'
-      })
-    end,
-  },
-}
-```
+Another option is to use `:h exrc`.
 
 ## :stethoscope: Troubleshooting
 

--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -3,8 +3,11 @@
 local server = {}
 
 ---@class rustaceanvim.LoadRASettingsOpts
----@field settings_file_pattern string|nil File name or pattern to search for. Defaults to 'rust-analyzer.json'
----@field default_settings table|nil Default settings to merge the loaded settings into
+---
+---(deprecated) File name or pattern to search for. Defaults to 'rust-analyzer.json'
+---@field settings_file_pattern string|nil
+---Default settings to merge the loaded settings into.
+---@field default_settings table|nil
 
 --- Load rust-analyzer settings from a JSON file,
 --- falling back to the default settings if none is found or if it cannot be decoded.
@@ -43,6 +46,7 @@ function server.load_rust_analyzer_settings(project_root, opts)
   if #results == 0 then
     return default_settings
   end
+  vim.deprecate('rust-analyzer.json', "'.vscode/settings.json' or ':h exrc'", '6.0.0', 'rustaceanvim')
   local config_json = results[1]
   local content = os.read_file(config_json)
   if not content then


### PR DESCRIPTION
* Adds support for ddc_source_lsp capabilities
  * Creates an array of tuples ( mod_name, server_capability_callback) and picks the first supported capability available for autocompletion plugin with nvim-lsp
  
  # Testing Reqs
* Ran `luarocks` test with 8 successes (no new tests added)