### PR TITLE
feat(lsp): more information on LSP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- LSP: Add more information to rust-analyzer unhealthy notifications
+
 ## [5.6.0] - 2024-09-18
 
 ### Added

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -10,6 +10,7 @@ local RustaceanConfig
 ---@class rustaceanvim.internal.RAInitializedStatus : rustaceanvim.RAInitializedStatus
 ---@field health rustaceanvim.lsp_server_health_status
 ---@field quiescent boolean inactive?
+---@field message string | nil
 ---
 ---@param dap_adapter rustaceanvim.dap.executable.Config | rustaceanvim.dap.server.Config | rustaceanvim.disable
 ---@return boolean


### PR DESCRIPTION
When the rust-analyzer server emits errors or warnings, display the additional message. Don't de-duplicate messages otherwise we loose the feedback on whether we have solved the issue.