### PR TITLE
feat(lsp): preserve cursor position for move_item command

### DIFF
--- a/lua/rustaceanvim/commands/move_item.lua
+++ b/lua/rustaceanvim/commands/move_item.lua
@@ -12,14 +12,41 @@ local function get_params(up)
   return params
 end
 
+local function extract_cursor_position(text_edits)
+  local cursor = { text_edits[1].range.start.line }
+  local prev_te
+  for _, te in ipairs(text_edits) do
+    if te.newText and te.insertTextFormat == 2 then
+      if not cursor[2] then
+        if prev_te then
+          cursor[1] = cursor[1]
+            + math.max(0, te.range.start.line - prev_te.range['end'].line - 1)
+            - (prev_te.range.start.line == te.range.start.line and 1 or 0)
+        end
+        local pos_start = string.find(te.newText, '%$0')
+        local lines = vim.split(string.sub(te.newText, 1, pos_start), '\n')
+        local total_lines = #lines
+        cursor[1] = cursor[1] + total_lines
+        if pos_start then
+          cursor[2] = (total_lines == 1 and te.range.start.character or 0) + #lines[total_lines] - 1
+        end
+      end
+    end
+    prev_te = te
+  end
+  return cursor
+end
+
 -- move it baby
 local function handler(_, result, ctx)
   if result == nil or #result == 0 then
     return
   end
+  local cursor = extract_cursor_position(result)
   local overrides = require('rustaceanvim.overrides')
   overrides.snippet_text_edits_to_text_edits(result)
   vim.lsp.util.apply_text_edits(result, ctx.bufnr, vim.lsp.get_client_by_id(ctx.client_id).offset_encoding)
+  vim.api.nvim_win_set_cursor(0, cursor)
 end
 
 local rl = require('rustaceanvim.rust_analyzer')


### PR DESCRIPTION
Port https://github.com/simrat39/rust-tools.nvim/pull/386

![](https://github.com/simrat39/rust-tools.nvim/assets/8050659/b828b9e0-a742-4d41-98f0-29033f8a7ce3)

```rust
pub struct Allergies(u32);

macro_rules! enum_iter {
    ($name: ident { $($variant: ident),* } ) => {
        #[derive(Debug, PartialEq, Eq, Clone)]
        pub enum $name {
            $( $variant, )*
        }

        impl $name {
            fn variants() -> Vec<$name> {
                vec![$( $name::$variant, )*]
            }
        }
    };
}

enum_iter!(Allergen {
    Eggs,
    Peanuts,
    Shellfish,
    Strawberries,
    Tomatoes,
    Chocolate,
    Pollen,
    Cats
});

impl Allergies {
    pub fn new(score: u32) -> Self {
        Allergies(score)
    }

    pub fn is_allergic_to(&self, allergen: &Allergen) -> bool {
        (self.0 & 1_u32 << allergen.clone() as u32) != 0
    }

    pub fn allergies(&self) -> Vec<Allergen> {
        Allergen::variants()
            .iter()
            .filter_map(|allergen| self.is_allergic_to(allergen).then_some(allergen.clone()))
            .collect()
    }
}
```