### PR TITLE
docs(mason): more generic config snippet

### DIFF
--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -14,11 +14,15 @@ the `server.cmd` setting (see |rustaceanvim.config| and |RustaceanLspClientOpts|
     server = {
       cmd = function()
 	local mason_registry = require('mason-registry')
-	local ra_binary = mason_registry.is_installed('rust-analyzer') 
-	  -- This may need to be tweaked, depending on the operating system.
-	  and mason_registry.get_package('rust-analyzer'):get_install_path() .. "/rust-analyzer"
-	  or "rust-analyzer"
-	return { ra_binary } -- You can add args to the list, such as '--log-file'
+	if mason_registry.is_installed('rust-analyzer') then
+	  -- This may need to be tweaked depending on the operating system.
+	  local ra = mason_registry.get_package('rust-analyzer')
+	  local ra_filename = ra:get_receipt():get().links.bin['rust-analyzer']
+	  return { ('%s/%s'):format(ra:get_install_path(), ra_filename or 'rust-analyzer') }
+	else
+	  -- global installation
+	  return { 'rust-analyzer' }
+	end
       end,
     },
   }


### PR DESCRIPTION
Hey, thanks for the great plugin !

Long story short, I've noticed that the executable name for the latest rust-analyzer shipped by Mason differs between OSes, but we can retrieve that from the metadata provided by Mason.

I've modified the docs in kind, but would be happy to contribute to a more automated discovery mechanism if desirable.

Hope this helps 🦀