### PR TITLE
chore(fixup): compatibility with nvim release

### DIFF
--- a/lua/rustaceanvim/compat.lua
+++ b/lua/rustaceanvim/compat.lua
@@ -23,7 +23,7 @@ end
 function compat.show_document(location, offset_encoding)
   local show_document = vim.lsp.show_document
   if not show_document then
-    vim.lsp.util.jump_to_location(location, offset_encoding)
+    return vim.lsp.util.jump_to_location(location, offset_encoding)
   end
   return show_document(location, offset_encoding, { focus = true })
 end


### PR DESCRIPTION
 Add missing return to avoid calling the nil show_document below.