### PR TITLE
feat(lsp): pass client_id to on_initialized (#582)

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -170,7 +170,7 @@ rustaceanvim.tools.Opts                                *rustaceanvim.tools.Opts*
         {enable_clippy?}                     (boolean)
                                                                                                        Whether to enable clippy checks on save if a clippy installation is detected.
                                                                                                        Default: `true`
-        {on_initialized?}                    (fun(health:rustaceanvim.RAInitializedStatus))
+        {on_initialized?}                    (fun(health:rustaceanvim.RAInitializedStatus,client_id:integer))
                                                                                                        Function that is invoked when the LSP server has finished initializing
         {reload_workspace_from_cargo_toml?}  (boolean)
                                                                                                        Automatically call `RustReloadWorkspace` when writing to a Cargo.toml file

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -78,7 +78,7 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---@field enable_clippy? boolean
 ---
 ---Function that is invoked when the LSP server has finished initializing
----@field on_initialized? fun(health:rustaceanvim.RAInitializedStatus)
+---@field on_initialized? fun(health:rustaceanvim.RAInitializedStatus,client_id:integer)
 ---
 ---Automatically call `RustReloadWorkspace` when writing to a Cargo.toml file
 ---@field reload_workspace_from_cargo_toml? boolean

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -106,7 +106,7 @@ local RustaceanDefaultConfig = {
 
     --- callback to execute once rust-analyzer is done initializing the workspace
     --- The callback receives one parameter indicating the `health` of the server: "ok" | "warning" | "error"
-    ---@type fun(health:rustaceanvim.RAInitializedStatus) | nil
+    ---@type fun(health:rustaceanvim.RAInitializedStatus,client_id:integer) | nil
     on_initialized = nil,
 
     --- automatically call RustReloadWorkspace when writing to a Cargo.toml file.

--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -58,7 +58,7 @@ see ':h rustaceanvim.lsp.ClientOpts'.
   end
   -- Load user on_initialized
   if config.tools.on_initialized then
-    config.tools.on_initialized(result)
+    config.tools.on_initialized(result, ctx.client_id)
   end
   if config.dap.autoload_configurations then
     require('rustaceanvim.commands.debuggables').add_dap_debuggables()


### PR DESCRIPTION
Fixes #582 .

This PR allows us to safely define and execute buffer-local commands in the `on_initialized` function by querying the buffers used by the LSP client identified by the newly added `client_id` parameter.

This is backward compatible, since the `client_id` was added after the existing parameter, not before.

## Testing
I did the following tests.

```lua
--[[
1. Open two Rust projects in a single Neovim instance.
cd project
nvim -o src/main.rs ~/another_rust_project/src/main.rs

2. Wait for the two LSP clients to finish indexing.

3. Run `:messages`.
I got the following output. It's working as expected.

{
  client_id = 1,
  status = {
    health = "ok",
    quiescent = true
  }
}
{
  client_id = 2,
  status = {
    health = "ok",
    quiescent = true
  }
}
]]
local function on_initialized(status, client_id)
    vim.print({ status = status, client_id = client_id })
end

--[[
1. Perform the same steps as above.

I got the following output.
It's working without the `client_id` parameter.
This is expected and backward compatible.

{
  status = {
    health = "ok",
    quiescent = true
  }
}
{
  status = {
    health = "ok",
    quiescent = true
  }
}
]]
local function backward_compatibility(status)
    vim.print({ status = status })
end

vim.g.rustaceanvim = {
    -- Please uncomment the one you want to test.
    -- tools = { on_initialized = on_initialized },
    -- tools = { on_initialized = backward_compatibility },
}
```