### PR TITLE
fix: expose `target` scommand in `:RustAnalyzer` command completion

### DIFF
--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -363,7 +363,7 @@ vim.api.nvim_create_user_command('RustAnalyzer', rust_analyzer_cmd, {
   complete = function(arg_lead, cmdline, _)
     local clients = rust_analyzer.get_active_rustaceanvim_clients()
     ---@type RustAnalyzerCmd[]
-    local commands = #clients == 0 and { 'start' } or { 'stop', 'restart', 'reloadSettings' }
+    local commands = #clients == 0 and { 'start' } or { 'stop', 'restart', 'reloadSettings', 'target' }
     if cmdline:match('^RustAnalyzer%s+%w*$') then
       return vim.tbl_filter(function(command)
         return command:find(arg_lead) ~= nil


### PR DESCRIPTION
This PR fixes  #588 by making the target architecture switching command for `RustAnalyzer` show up in neovim's command auto completion.
![rustanalyzercmd-fixed](https://github.com/user-attachments/assets/55a8f0bd-dc78-41bd-b210-ecde7e48bdff)

