### PR TITLE
fix: various `:RustAnalyzer target` regressions

### DIFF
--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -353,7 +353,7 @@ local function rust_analyzer_cmd(opts)
     M.reload_settings()
   elseif cmd == RustAnalyzerCmd.target then
     local target_arch = fargs[2]
-    M.set_target_arch(target_arch)
+    M.set_target_arch(nil, target_arch)
   end
 end
 

--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -311,7 +311,11 @@ M.set_target_arch = function(bufnr, target)
   restart(bufnr, { exclude_rustc_target = target }, function(client)
     rustc.with_rustc_target_architectures(function(rustc_targets)
       if rustc_targets[target] then
-        client.settings['rust-analyzer'].cargo.target = target
+        -- NOTE: It is not guaranteed that the 'cargo' subkey exists (atleast rustaceanvim does
+        -- not configure it by default).
+        local ra = client.config.settings['rust-analyzer']
+        ra.cargo = ra.cargo or {} -- Initialize the cargo subkey if necessary
+        ra.cargo.target = target
         client.notify('workspace/didChangeConfiguration', { settings = client.config.settings })
         vim.notify('Target architecture updated successfully to: ' .. target, vim.log.levels.INFO)
         return

--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -311,10 +311,8 @@ M.set_target_arch = function(bufnr, target)
   restart(bufnr, { exclude_rustc_target = target }, function(client)
     rustc.with_rustc_target_architectures(function(rustc_targets)
       if rustc_targets[target] then
-        -- NOTE: It is not guaranteed that the 'cargo' subkey exists (atleast rustaceanvim does
-        -- not configure it by default).
         local ra = client.config.settings['rust-analyzer']
-        ra.cargo = ra.cargo or {} -- Initialize the cargo subkey if necessary
+        ra.cargo = ra.cargo or {}
         ra.cargo.target = target
         client.notify('workspace/didChangeConfiguration', { settings = client.config.settings })
         vim.schedule(function()

--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -317,10 +317,14 @@ M.set_target_arch = function(bufnr, target)
         ra.cargo = ra.cargo or {} -- Initialize the cargo subkey if necessary
         ra.cargo.target = target
         client.notify('workspace/didChangeConfiguration', { settings = client.config.settings })
-        vim.notify('Target architecture updated successfully to: ' .. target, vim.log.levels.INFO)
+        vim.schedule(function()
+          vim.notify('Target architecture updated successfully to: ' .. target, vim.log.levels.INFO)
+        end)
         return
       else
-        vim.notify('Invalid target architecture provided: ' .. tostring(target), vim.log.levels.ERROR)
+        vim.schedule(function()
+          vim.notify('Invalid target architecture provided: ' .. tostring(target), vim.log.levels.ERROR)
+        end)
         return
       end
     end)


### PR DESCRIPTION
This PR addresses three issues that would prevent a user from successfully running `:RustAnalyzer target`. It is pretty much a follow up to https://github.com/mrcjkb/rustaceanvim/pull/589 and https://github.com/mrcjkb/rustaceanvim/pull/548.

Each commit fixes one issue, and I will explain them in order:

### 1.`bufnr` argument missing when calling `set_target_arch`
 `:RustAnalyzer target` would call `set_target_arch` by passing the target triple as the `bufnr` argument. Seems to be a regression introduced in https://github.com/mrcjkb/rustaceanvim/pull/548 AFAICT.

### 2. Access non-existant key in `rust-analyzer` config / map
Inside `set_target_arch`, we would try to update a nested map (`rust-analyzer`)  without first checking if each subkey was present. Specifically, `client.settings['rust-analyzer'].cargo` was `nil`, leading to the following statement failing catastrophically: `client.settings['rust-analyzer'].cargo.target = target`.

Curiously, it seems like `rust-analyzer` is present in `client.config.settings` and _not_ `client.settings`, so I updated that. Works on my machine ¯\\_(ツ)_/¯.

### 3. `vim.notify` was called at an inappropriate time

When `set_target_arch` is done updating the `rust-analyzer` config it will print a status update to the echo area using `vim.notify`. Apparently neovim didn't like this, and I got the following stacktrace after (successfully) calling `:RustAnalyzer target aarch64-linux-android`:

```bash
Error executing luv callback:
vim/_editor.lua:0: E5560: nvim_echo must not be called in a lua loop callback
stack traceback:
        [C]: in function 'nvim_echo'
        vim/_editor.lua: in function 'notify'
        .../rustaceanvim/lua/rustaceanvim/lsp/init.lua:321: in function 'on_exit'
        /usr/share/nvim/runtime/lua/vim/_system.lua:300: in function </usr/share/nvim/runtime/lua/vim/_system.lua:270>
        [C]: in function 'wait'
        /usr/share/nvim/runtime/lua/vim/_system.lua:98: in function 'wait'
        .../rustaceanvim/lua/rustaceanvim/cargo.lua:68: in function 'get_cargo_metadata'
        .../rustaceanvim/lua/rustaceanvim/cargo.lua:110: in function 'get_config_root_dir'
        .../rustaceanvim/lua/rustaceanvim/lsp/init.lua:159: in function 'start'
        .../rustaceanvim/lua/rustaceanvim/lsp/init.lua:121: in function <.../rustaceanvim/lua/rustaceanvim/lsp/init.lua:116>
```

Scheduling the status update with [vim.schedule](https://neovim.io/doc/user/lua.html#vim.schedule()) seems do have done the trick.

### Final remarks
 Sorry for not creating separate issues for all of the included fixes, but I patched the code as I went along and stumbled upon one error after the next. I love this package, and I hope that my work here will be useful to others. Cheers!