### PR TITLE
feat(diagnostics): focus preview window when invoking commands again with `current` argument

### DIFF
--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -73,6 +73,7 @@ function M.explain_error()
     vim.notify('No explainable errors found.', vim.log.levels.INFO)
     return
   end
+  close_hover()
   local win_id = vim.api.nvim_get_current_win()
   local opts = {
     cursor_position = vim.api.nvim_win_get_cursor(win_id),
@@ -128,15 +129,11 @@ function M.explain_error()
     table.insert(float_preview_lines, 1, '---')
     table.insert(float_preview_lines, 1, '1. Open in split')
     vim.schedule(function()
-      close_hover()
       local bufnr, winnr = vim.lsp.util.open_floating_preview(
         float_preview_lines,
         'markdown',
         vim.tbl_extend('keep', config.tools.float_win_config, {
-          focus = false,
-          focusable = true,
           focus_id = 'rustc-explain-error',
-          close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
         })
       )
       _window_state.float_winnr = winnr
@@ -203,15 +200,11 @@ function M.explain_error_current_line()
     table.insert(float_preview_lines, 1, '---')
     table.insert(float_preview_lines, 1, '1. Open in split')
     vim.schedule(function()
-      close_hover()
       local bufnr, winnr = vim.lsp.util.open_floating_preview(
         float_preview_lines,
         'markdown',
         vim.tbl_extend('keep', config.tools.float_win_config, {
-          focus = false,
-          focusable = true,
           focus_id = 'rustc-explain-error',
-          close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
         })
       )
       _window_state.float_winnr = winnr
@@ -252,15 +245,11 @@ local function render_ansi_code_diagnostic(rendered_diagnostic)
   table.insert(float_preview_lines, 1, '---')
   table.insert(float_preview_lines, 1, '1. Open in split')
   vim.schedule(function()
-    close_hover()
     local bufnr, winnr = vim.lsp.util.open_floating_preview(
       float_preview_lines,
-      '',
+      'plaintext',
       vim.tbl_extend('keep', config.tools.float_win_config, {
-        focus = false,
-        focusable = true,
         focus_id = 'ra-render-diagnostic',
-        close_events = { 'CursorMoved', 'BufHidden', 'InsertCharPre' },
       })
     )
     vim.api.nvim_create_autocmd('WinEnter', {
@@ -322,6 +311,7 @@ function M.render_diagnostic()
     vim.notify('No renderable diagnostics found.', vim.log.levels.INFO)
     return
   end
+  close_hover()
   local win_id = vim.api.nvim_get_current_win()
   local opts = {
     cursor_position = vim.api.nvim_win_get_cursor(win_id),


### PR DESCRIPTION
Update: updated the description according mrcjkb's newest requirements.

As the title said, running the commands twice will focus the pop up instead of closing the hover and opening it again.

According to neovim's documentation for
vim.lsp.util.open_floating_preview:

> If `true`, and if {focusable} is also `true`, focus an existing floating
> window with the same {focus_id}
> (default: `true`)

Removing the focus=false, and removing call to close_hover enable users
to enter the hover.

I removed the your parameter focus=false, so that nvim will use the default parameter focus=true, then when calling the open_floating_preview twice, it would focus an existing floating window with the same {focus_id}. 

If you have any other questions or understanding the code, please run `:h vim.lsp.util.open_floating_preview()` or check out `runtime/lua/vim/lsp/util.lua:1520` in neovim's source code for their implementation.