### PR TITLE
fix(neotest): prevent running multiple tests when running a single test with cargo-nextest

### DIFF
--- a/lua/rustaceanvim/overrides.lua
+++ b/lua/rustaceanvim/overrides.lua
@@ -49,7 +49,6 @@ function M.try_nextest_transform(args)
     table.remove(args, #args)
   end
   local nextest_unsupported_flags = {
-    '--exact',
     '--show-output',
   }
   local indexes_to_remove_reverse_order = {}


### PR DESCRIPTION
Fixes https://github.com/mrcjkb/rustaceanvim/issues/618.

I have tested this manually:

1. Uninstalled the `cargo-nextest`

<img width="1091" alt="Screenshot 2024-12-17 at 15 45 39" src="https://github.com/user-attachments/assets/f50a8a65-5d64-4923-b70c-8e784b3514a9" />

2. Installed 0.9.80 (which does not support the flag)

<img width="1252" alt="Screenshot 2024-12-17 at 15 49 26" src="https://github.com/user-attachments/assets/2487fc3c-d811-4d3f-90da-f2237f7b9f30" />

3. Installed the correct version

<img width="585" alt="Screenshot 2024-12-17 at 15 52 03" src="https://github.com/user-attachments/assets/f2f483de-f8b1-4975-b18f-f3afaf415b88" />


I have tested the tests are now not executed if not needed (for example when running `test_function_1`:

```
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.01s
────────────
 Nextest run ID a08a7486-cd35-4d6d-b0ce-4cde971c1b3c with nextest profile: default
    Starting 1 test across 1 binary (1 test skipped)
        PASS [   0.017s] rust-test::bin/rust-test test::test_function_1
────────────
     Summary [   0.019s] 1 test run: 1 passed, 1 skipped
```
