### PR TITLE
Add way to provide extra `initCommands`

### DIFF
--- a/lua/rustaceanvim/commands/debuggables.lua
+++ b/lua/rustaceanvim/commands/debuggables.lua
@@ -137,6 +137,12 @@ local function add_debuggables_to_nvim_dap(debuggables)
       local name = 'Cargo: ' .. build_label(debuggable.args)
       if not _dap_configuration_added[name] then
         configuration.name = name
+        if configuration.initCommands == nil then
+          configuration.initCommands = {}
+        end
+        if config.dap.init_commands ~= nil then
+          table.insert(configuration.initCommands, config.dap.init_commands)
+        end
         table.insert(dap.configurations.rust, configuration)
         _dap_configuration_added[name] = true
       end

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -261,6 +261,9 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---Whether to get Rust types via initCommands (rustlib/etc/lldb_commands, lldb only).
 ---Default: `true`.
 ---@field load_rust_types? fun():boolean | boolean
+---
+---Extra initCommand to apply to all debuggable targets
+---@field init_commands? string
 
 ---@alias rustaceanvim.dap.Command string
 

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -409,6 +409,8 @@ local RustaceanDefaultConfig = {
       local type = is_codelldb_adapter(adapter) and 'codelldb' or 'lldb'
       return load_dap_configuration(type)
     end,
+    ---@type string?
+    init_commands = nil,
   },
   -- debug info
   was_g_rustaceanvim_sourced = vim.g.rustaceanvim ~= nil,


### PR DESCRIPTION
Hello,

first of all thanks for this great plugin, it's my daily driver for a long time one :pray: 

I have a particular feature that I'm lacking or don't know how to achieve in `rustaceanvim` when it comes to debugging: I have a custom lldb init script in my repo (which adds some custom formatters) which I want to apply to _every_ debuggable target there is (executables, nvim-dap targets & neotest debug targets), when using the `codelldb` adapter.

AFAIK I can only provide `initCommands` in the `.vscode/launch.json`, which works for executables, but not for the tests, right?

My idea was let the user configure an optional command in its config, which gets appended to all other init commands of all targets. My user config now looks like this:

```lua
  {
    "mrcjkb/rustaceanvim",
    dependencies = { "mfussenegger/nvim-dap" },
    version = "^5",
    lazy = false,
    ft = { "rust" },
    opts = {
      dap = {
        autoload_configurations = true,
        init_commands = "command script import ./lldb/fleet.py",
      },
    }
    -- other config...
}
```

Maybe there is another already built in way how to solve this, comments very welcome (=