### PR TITLE
docs: mention support for blink.cmp capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -917,10 +917,11 @@ Neovim has built-in completion based on the `triggerCharacters` sent by
 language servers.
 Omni completion is also available for a more traditional `vim`-like completion experience.
 
-For more extensible and complex autocompletion setups you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
-and a LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp).
+For more extensible and complex autocompletion setups, you need a plugin such as [`nvim-cmp`](https://github.com/hrsh7th/nvim-cmp)
+and a LSP completion source like [`cmp-nvim-lsp`](https://github.com/hrsh7th/cmp-nvim-lsp),
+or you may use [`blink.cmp`](https://github.com/saghen/blink.cmp).
 This plugin will automatically register the necessary client capabilities
-if you have `cmp-nvim-lsp` installed.
+if you have either `cmp-nvim-lsp` or `blink.cmp` installed.
 
 #### I'm having issues with (auto)completion
 


### PR DESCRIPTION
Read this section and didn't realize that it'll also detect and setup capabilities for `blink.cmp`, until I dug into the code. Figured it was worth adding to the docs. Thanks for all your work on this!