### PR TITLE
feat(dap): extra cargo executable args config option

### DIFF
--- a/lua/rustaceanvim/commands/debuggables.lua
+++ b/lua/rustaceanvim/commands/debuggables.lua
@@ -185,6 +185,24 @@ end
 ---@param executableArgsOverride? string[]
 function M.debuggables(executableArgsOverride)
   runnables_request(mk_handler(function(debuggables)
+
+    local extra_exec_args_opt = config.dap.cargo_executable_args
+    if extra_exec_args_opt ~= nil then
+        local args = {}
+        if type(extra_exec_args_opt) == "function" then
+            args = extra_exec_args_opt()
+        elseif type(extra_exec_args_opt) == "table" then
+            args = extra_exec_args_opt
+        end
+        if #args > 0 then
+            for _, debuggable in ipairs(debuggables) do
+                for _, arg in ipairs(args) do
+                    table.insert(debuggable.args.executableArgs, arg)
+                end
+            end
+        end
+    end
+
     ui_select_debuggable(debuggables, executableArgsOverride)
   end))
 end

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -271,6 +271,13 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---Whether to get Rust types via initCommands (rustlib/etc/lldb_commands, lldb only).
 ---Default: `true`.
 ---@field load_rust_types? fun():boolean | boolean
+---
+---Some extra executable args of `cargo` for debugging.
+---By default the executable args could be like: `{ "tests::basic_tests", "--exact", "--show-output" }`,
+---and you can append some extra args to it by modifying this opt, like `cargo_executable_args = { "--nocapture" }`
+---then the final args is `{ "tests::basic_tests", "--exact", "--show-output", "--nocapture" }`
+---Default: {}
+---@field cargo_executable_args? fun():string[] | string[]
 
 ---@alias rustaceanvim.dap.Command string
 


### PR DESCRIPTION
#445

This PR supports the feature: allowing user to pass extra customized executable args to cargo for debugging.

Added: a opt `vim.g.rustaceanvim.dap.cargo_executable_args`
Affected: the behavior of `RustLsp debuggables`