### PR TITLE
fix(lsp): FlyCheck request params

### DIFF
--- a/lua/rustaceanvim/commands/fly_check.lua
+++ b/lua/rustaceanvim/commands/fly_check.lua
@@ -2,11 +2,15 @@ local M = {}
 
 local rl = require('rustaceanvim.rust_analyzer')
 
+local function make_flycheck_params()
+  return { textDocument = vim.lsp.util.make_text_document_params() }
+end
+
 ---@alias rustaceanvim.flyCheckCommand 'run' | 'clear' | 'cancel'
 
 ---@param cmd rustaceanvim.flyCheckCommand
 function M.fly_check(cmd)
-  local params = cmd == 'run' and vim.lsp.util.make_text_document_params() or nil
+  local params = cmd == 'run' and make_flycheck_params() or nil
   rl.notify('rust-analyzer/' .. cmd .. 'Flycheck', params)
 end
 


### PR DESCRIPTION
Hi, I encountered a problem and try to solve it.

When I manually trigger a flyCheck via `:RustLsp flyCheck`, the rust analyzer does not perform the corresponding flyCheck.

The minimal configuration of rust analyzer as follows.
```lua
["rust-analyzer"] = {
	check = {
		command = "check",
		workspace = false,
	},
}
```

Looked through the code of the rust analyzer and found that the serialization of the `flycheck_params` is problematic. The related code see [here](https://github.com/rust-lang/rust-analyzer/blob/62e7d9f0fc2a3499be2ed819c572da875e564ee0/crates/rust-analyzer/src/lsp/ext.rs#L373-L377).

And this PR fixes the serialization problem of `flycheck_params`.
