### PR TITLE
fix(hover_range): missing border

### DIFF
--- a/lua/rustaceanvim/commands/hover_range.lua
+++ b/lua/rustaceanvim/commands/hover_range.lua
@@ -81,8 +81,17 @@ local function handler(_, result, _)
     })
   )
 
+  vim.api.nvim_create_autocmd('WinEnter', {
+    callback = function()
+      vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Esc>', true, false, true), 'n', true)
+    end,
+    buffer = bufnr,
+  })
+
   if win_opt.auto_focus then
     vim.api.nvim_set_current_win(winnr)
+
+    vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Esc>', true, false, true), 'n', true)
   end
 
   if _state.winnr ~= nil then


### PR DESCRIPTION
When I remove `vim.lsp.handlers[vim.lsp.protocol.Methods.textDocument_hover] = vim.lsp.with(vim.lsp.handlers.hover, { border = "single" })` in neovim 0.11, hover range missing border.

I tried `vim.opt.winborder = "single"` but it was too noise.

I noticed that when I press `KK`(the K call hover range) continuously it stays in visual mod, and I need press `<esc>q` for exit float window so I let it automatically switch to nomal mod.