### PR TITLE
fix: deprecation warning on go to definition hover action (nvim 0.11)

### DIFF
--- a/lua/rustaceanvim/compat.lua
+++ b/lua/rustaceanvim/compat.lua
@@ -21,7 +21,7 @@ end
 ---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'?
 ---@return boolean `true` if the jump succeeded
 function compat.show_document(location, offset_encoding)
-  local show_document = vim.lsp.show_document
+  local show_document = vim.lsp.util.show_document
   if not show_document then
     return vim.lsp.util.jump_to_location(location, offset_encoding or 'utf-8')
   end


### PR DESCRIPTION
I assume that this issue was silent, because we used `jump_to_location` method instead. Since now this method is deprecated we can see that `show_document` is never called. The correct location of `show_document` method is in [util](https://neovim.io/doc/user/lsp.html#vim.lsp.util.show_document())

closes #710
