### PR TITLE
fix: do not resize expand_macro buffer

### DIFF
--- a/lua/rustaceanvim/commands/expand_macro.lua
+++ b/lua/rustaceanvim/commands/expand_macro.lua
@@ -60,9 +60,6 @@ local function handler(_, result)
   vim.bo[latest_buf_id].filetype = 'rust'
   -- write the expansion content to the buffer
   vim.api.nvim_buf_set_lines(latest_buf_id, 0, 0, false, parse_lines(result))
-
-  -- make the new buffer smaller
-  ui.resize(true, '-25')
 end
 
 --- Sends the request to rust-analyzer to expand the macro under the cursor


### PR DESCRIPTION
This makes the `expand_macro` command a better fit for chaining it with layout commands.