### PR TITLE
docs: update rust-analyzer config links

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ To modify the default configuration, set `vim.g.rustaceanvim`.
   You may need to run `:helptags ALL` if the documentation has not been installed.
 - The default configuration [can be found here (see `RustaceanDefaultConfig`)](./lua/rustaceanvim/config/internal.lua).
 - For detailed descriptions of the language server configs,
-  see the [`rust-analyzer` documentation](https://rust-analyzer.github.io/manual.html#configuration).
+  see the [`rust-analyzer` documentation](https://rust-analyzer.github.io/book/configuration.html).
 
 You only need to specify the keys
 that you want to be changed, because defaults
@@ -856,7 +856,7 @@ If the file does not exist, or it can't be decoded,
 the `server.default_settings` will be used.
 
 [^2]: See [this example](https://github.com/rust-analyzer/rust-project.json-example/blob/master/.vscode/settings.json)
-      and the rust-analyzer [configuration manual](https://rust-analyzer.github.io/manual.html#configuration).
+      and the rust-analyzer [configuration manual](https://rust-analyzer.github.io/book/configuration.html).
       Note that JSON5 is currently not supported by Neovim.
 
 Another option is to use `:h exrc`.

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -332,7 +332,7 @@ rustaceanvim.lsp.ClientOpts                        *rustaceanvim.lsp.ClientOpts*
         {settings?}              (table|fun(project_root:string|nil,default_settings:table):table)
                                                                                                                               Setting passed to rust-analyzer.
                                                                                                                               Defaults to a function that looks for a `rust-analyzer.json` file or returns an empty table.
-                                                                                                                              See https://rust-analyzer.github.io/manual.html#configuration.
+                                                                                                                              See https://rust-analyzer.github.io/book/configuration.html.
         {standalone?}            (boolean)
                                                                                                                               Standalone file support (enabled by default).
                                                                                                                               Disabling it may improve rust-analyzer's startup time.
@@ -521,7 +521,7 @@ server.load_rust_analyzer_settings({project_root}, {opts})
         (table)  server_settings
 
     See: ~
-        |https://rust-analyzer.github.io/manual.html#configuration|
+        |https://rust-analyzer.github.io/book/configuration.html|
 
 
 server.create_client_capabilities()          *server.create_client_capabilities*


### PR DESCRIPTION
This PR fixes some outdated links to the rust-analyzer configuration documentation.