### PR TITLE
fix(lsp): codeActions not found if multiple clients are active

### DIFF
--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -126,7 +126,8 @@ local function on_code_action_results(results, ctx)
 
   ---@type rustaceanvim.CodeActionItem[]
   local action_items = {}
-  for _, result in ipairs(results) do
+  for i = 1, #t do
+    local result = t[i] or {}
     for _, action in ipairs(result.result or {}) do
       table.insert(action_items, { action = action, ctx = ctx })
     end

--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -126,11 +126,10 @@ local function on_code_action_results(results, ctx)
 
   ---@type rustaceanvim.CodeActionItem[]
   local action_items = {}
-  for i = 1, #t do
-    local result = t[i] or {}
-    for _, action in ipairs(result.result or {}) do
-      table.insert(action_items, { action = action, ctx = ctx })
-    end
+  local index = vim.lsp.get_clients({ name = "rust-analyzer" })[1].id
+  for _, action in ipairs(results[index].result or {}) do
+    table.insert(action_items, { action = action, ctx = ctx })
+  end
   end
   if #action_items == 0 then
     vim.notify('No code actions available', vim.log.levels.INFO)

--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -126,10 +126,10 @@ local function on_code_action_results(results, ctx)
 
   ---@type rustaceanvim.CodeActionItem[]
   local action_items = {}
-  local index = vim.lsp.get_clients({ name = "rust-analyzer" })[1].id
-  for _, action in ipairs(results[index].result or {}) do
-    table.insert(action_items, { action = action, ctx = ctx })
-  end
+  for _, result in pairs(results) do
+    for _, action in ipairs(results.result or {}) do
+      table.insert(action_items, { action = action, ctx = ctx })
+    end
   end
   if #action_items == 0 then
     vim.notify('No code actions available', vim.log.levels.INFO)

--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -127,7 +127,7 @@ local function on_code_action_results(results, ctx)
   ---@type rustaceanvim.CodeActionItem[]
   local action_items = {}
   for _, result in pairs(results) do
-    for _, action in ipairs(results.result or {}) do
+    for _, action in ipairs(result.result or {}) do
       table.insert(action_items, { action = action, ctx = ctx })
     end
   end


### PR DESCRIPTION
This fixes #744, which was thought to be caused by "copilot.vim", but actually happens anytime `rust-analyzer` does not have `id: 1`. We thought that this case was already handled (see: https://github.com/mrcjkb/rustaceanvim/issues/744#issuecomment-2848679366), but it turns out that it wasn't.

According to the lua manual:

> ipairs (t)
> 
> Returns three values (an iterator function, the table t, and 0) so that the construction
> 
>      for i,v in ipairs(t) do body end
> 
> will iterate over the key–value pairs (1,t[1]), (2,t[2]), ..., __up to the first absent index__. (emphasis mine).

What happens is that the `result` table returned by 
```lua
vim.lsp.buf_request_all(0, 'textDocument/codeAction', params, function(results, ctx) 
-- handle `result` table.
end)
```
is sparse with respect to the LSPs that return a codeAction table. So consider `rust-analyzer` has `id: 2`, and the LSP with `id: 1` does not return a codeAction table (presumably because the lsp is not made for rust files). Then `ipairs` will stop at index 1 and return nil, since it _stops at the first absent index_.

This PR fixes the bug by indexing only the codeActions provided by `rust-analyzer`.

@mrcjkb, when you tested out with null-ls, I believe you simply got lucky and `rust-analyzer` happened to be the lsp with `id: 1`.
 