### PR TITLE
fix(lsp/codeAction): missing `execute_command` function

### DIFF
--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -33,8 +33,9 @@ function M.apply_action(action, client, ctx)
     local fn = vim.lsp.commands[command.command]
     if fn then
       fn(command, ctx)
-    else
-      M.execute_command(command)
+    elseif type(command) == 'string' then
+      local tools = config.tools
+      pcall(tools.executor.execute_command, command, {})
     end
   end
 end


### PR DESCRIPTION
Should fix an old bug that has been present since the inception of the code action group feature in rust-tools.nvim.

Closes #753.