### PR TITLE
feat(lsp): add `cycle_prev` arg to `explainError` and `renderDiagnostic` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,11 +448,12 @@ vim.keymap.set(
   over error diagnostics (if they have an error code).
   
   ```vim
-  :RustLsp explainError {cycle?|current?}
+  :RustLsp explainError {cycle?|cycle_prev?|current?}
   ```
   ```lua
   vim.cmd.RustLsp('explainError') -- default to 'cycle'
   vim.cmd.RustLsp({ 'explainError', 'cycle' })
+  vim.cmd.RustLsp({ 'explainError', 'cycle_prev' })
   vim.cmd.RustLsp({ 'explainError', 'current' })
   ```
 
@@ -461,6 +462,10 @@ vim.keymap.set(
     `explainError` will cycle diagnostics,
     starting at the cursor position,
     until it can find a diagnostic with an error code.
+
+  - If called with `cycle_prev`:
+    Like `vim.diagnostic.goto_prev`,
+    searches backwards for a diagnostic with an error code.
     
   - If called with `current`:
     Searches for diagnostics only in the
@@ -482,11 +487,12 @@ vim.keymap.set(
   together.
   
   ```vim
-  :RustLsp renderDiagnostic {cycle?|current?}
+  :RustLsp renderDiagnostic {cycle?|cycle_prev?|current?}
   ```
   ```lua
   vim.cmd.RustLsp('renderDiagnostic') -- defaults to 'cycle'
   vim.cmd.RustLsp({ 'renderDiagnostic', 'cycle' })
+  vim.cmd.RustLsp({ 'renderDiagnostic', 'cycle_prev' })
   vim.cmd.RustLsp({ 'renderDiagnostic', 'current' })
   ```
 
@@ -495,6 +501,10 @@ vim.keymap.set(
     `renderDiagnostic` will cycle diagnostics,
     starting at the cursor position,
     until it can find a diagnostic with rendered data.
+
+  - If called with `cycle_prev`:
+    Like `vim.diagnostic.goto_prev`,
+    searches backwards for a diagnostic with rendered data.
     
   - If called with `current`:
     Searches for diagnostics only in the

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -62,22 +62,28 @@ It accepts the following subcommands:
 
                For example, if you set the keymap: `vim.keymap.set('n', '<space>a', '<Plug>RustHoverAction')`,
                you can invoke the third hover action with `3<space>a`.
- 'explainError {cycle?|current?}' - Display a hover window with explanations form the Rust error index.
+ 'explainError {cycle?|cycle_prev?|current?}' - Display a hover window with explanations form the Rust error index.
             - If called with |cycle| or no args:
               Like |vim.diagnostic.goto_next|,
               |explainError| will cycle diagnostics,
               starting at the cursor position,
               until it can find a diagnostic with an error code.
+            - If called with |cycle_prev|:
+              Like |vim.diagnostic.goto_prev|,
+              searches backwards for a diagnostic with an error code.
             - If called with |current|:
               Searches for diagnostics only in the
               current cursor line.
- 'renderDiagnostic {cycle?|current?}' - Display a hover window with the rendered diagnostic,
+ 'renderDiagnostic {cycle?|cycle_prev?|current?}' - Display a hover window with the rendered diagnostic,
             as displayed during |cargo build|.
             - If called with |cycle| or no args:
               Like |vim.diagnostic.goto_next|,
               |renderDiagnostic| will cycle diagnostics,
               starting at the cursor position,
               until it can find a diagnostic with rendered data.
+            - If called with |cycle_prev|:
+              Like |vim.diagnostic.goto_prev|,
+              searches backwards for a diagnostic with rendered data.
             - If called with |current|:
               Searches for diagnostics only in the
               current cursor line.

--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -54,7 +54,8 @@ local function set_close_keymaps(bufnr)
   vim.keymap.set('n', '<Esc>', close_hover, { buffer = bufnr, noremap = true, silent = true })
 end
 
-function M.explain_error()
+---@param cycle_diagnostic (fun(opts?: vim.diagnostic.JumpOpts): vim.Diagnostic?)
+function M.explain_error(cycle_diagnostic)
   if vim.fn.executable(rustc) ~= 1 then
     vim.notify('rustc is needed to explain errors.', vim.log.levels.ERROR)
     return
@@ -86,7 +87,7 @@ function M.explain_error()
   ---@type string
   local pos_id = '0'
   repeat
-    diagnostic = vim.diagnostic.get_next(opts)
+    diagnostic = cycle_diagnostic(opts)
     pos_map[pos_id] = diagnostic
     if diagnostic == nil then
       break
@@ -299,7 +300,8 @@ local function render_ansi_code_diagnostic(rendered_diagnostic)
   end)
 end
 
-function M.render_diagnostic()
+---@param cycle_diagnostic (fun(opts?: vim.diagnostic.JumpOpts): vim.Diagnostic?)
+function M.render_diagnostic(cycle_diagnostic)
   local diagnostics = vim
     .iter(vim.diagnostic.get(0, {}))
     ---@param diagnostic vim.Diagnostic
@@ -323,7 +325,7 @@ function M.render_diagnostic()
   ---@type string
   local pos_id = '0'
   repeat
-    diagnostic = vim.diagnostic.get_next(opts)
+    diagnostic = cycle_diagnostic(opts)
     pos_map[pos_id] = diagnostic
     if diagnostic == nil then
       break

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -63,18 +63,20 @@ local rustlsp_command_tbl = {
     impl = function(args)
       local subcmd = args[1] or 'cycle'
       if subcmd == 'cycle' then
-        require('rustaceanvim.commands.diagnostic').explain_error()
+        require('rustaceanvim.commands.diagnostic').explain_error(vim.diagnostic.get_next)
+      elseif subcmd == 'cycle_prev' then
+        require('rustaceanvim.commands.diagnostic').explain_error(vim.diagnostic.get_prev)
       elseif subcmd == 'current' then
         require('rustaceanvim.commands.diagnostic').explain_error_current_line()
       else
         vim.notify(
-          'explainError: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'",
+          'explainError: unknown subcommand: ' .. subcmd .. " expected 'cycle', 'cycle_prev', or 'current'",
           vim.log.levels.ERROR
         )
       end
     end,
     complete = function()
-      return { 'cycle', 'current' }
+      return { 'cycle', 'cycle_prev', 'current' }
     end,
   },
   relatedDiagnostics = {
@@ -86,18 +88,20 @@ local rustlsp_command_tbl = {
     impl = function(args)
       local subcmd = args[1] or 'cycle'
       if subcmd == 'cycle' then
-        require('rustaceanvim.commands.diagnostic').render_diagnostic()
+        require('rustaceanvim.commands.diagnostic').render_diagnostic(vim.diagnostic.get_next)
+      elseif subcmd == 'cycle_prev' then
+        require('rustaceanvim.commands.diagnostic').render_diagnostic(vim.diagnostic.get_prev)
       elseif subcmd == 'current' then
         require('rustaceanvim.commands.diagnostic').render_diagnostic_current_line()
       else
         vim.notify(
-          'renderDiagnostic: unknown subcommand: ' .. subcmd .. " expected 'cycle' or 'current'",
+          'renderDiagnostic: unknown subcommand: ' .. subcmd .. " expected 'cycle', 'cycle_prev', or 'current'",
           vim.log.levels.ERROR
         )
       end
     end,
     complete = function()
-      return { 'cycle', 'current' }
+      return { 'cycle', 'cycle_prev', 'current' }
     end,
   },
   rebuildProcMacros = {

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -55,22 +55,28 @@
 ---
 ---               For example, if you set the keymap: `vim.keymap.set('n', '<space>a', '<Plug>RustHoverAction')`,
 ---               you can invoke the third hover action with `3<space>a`.
---- 'explainError {cycle?|current?}' - Display a hover window with explanations form the Rust error index.
+--- 'explainError {cycle?|cycle_prev?|current?}' - Display a hover window with explanations form the Rust error index.
 ---            - If called with |cycle| or no args:
 ---              Like |vim.diagnostic.goto_next|,
 ---              |explainError| will cycle diagnostics,
 ---              starting at the cursor position,
 ---              until it can find a diagnostic with an error code.
+---            - If called with |cycle_prev|:
+---              Like |vim.diagnostic.goto_prev|,
+---              searches backwards for a diagnostic with an error code.
 ---            - If called with |current|:
 ---              Searches for diagnostics only in the
 ---              current cursor line.
---- 'renderDiagnostic {cycle?|current?}' - Display a hover window with the rendered diagnostic,
+--- 'renderDiagnostic {cycle?|cycle_prev?|current?}' - Display a hover window with the rendered diagnostic,
 ---            as displayed during |cargo build|.
 ---            - If called with |cycle| or no args:
 ---              Like |vim.diagnostic.goto_next|,
 ---              |renderDiagnostic| will cycle diagnostics,
 ---              starting at the cursor position,
 ---              until it can find a diagnostic with rendered data.
+---            - If called with |cycle_prev|:
+---              Like |vim.diagnostic.goto_prev|,
+---              searches backwards for a diagnostic with rendered data.
 ---            - If called with |current|:
 ---              Searches for diagnostics only in the
 ---              current cursor line.


### PR DESCRIPTION
This adds a `cycle_prev` option to `explainError` and `renderDiagnostic` like `vim.diagnostic.goto_prev`.