### PR TITLE
doc(vimdoc): update doc for mason v2.0.0

### DIFF
--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -36,6 +36,16 @@ General approach to prevent mason-lspconfig from setting up
 `lspconfig.rust_analyzer`:
 
 >lua
+  opts = {
+    automatic_enable = {
+      exclude = { "rust_analyzer" }
+    }
+  }
+<
+
+On mason.nvim below v2.0.0 (or neovim below v0.11.0):
+
+>lua
   require('mason-lspconfig').setup_handlers {
     ['rust_analyzer'] = function() end,
   }


### PR DESCRIPTION
Mason v2.0.0 introduced changes that made the instructions in doc/mason.txt invalid. Notably, they removed `setup_handlers` from `mason-lspconfig`. I have added the appropriate instructions for the new API.