### PR TITLE
feat(lsp/runnables): support `runnable.args.environment`

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -229,6 +229,8 @@ rustaceanvim.ExecutorOpts                            *rustaceanvim.ExecutorOpts*
     Fields: ~
         {bufnr?}  (integer)
                              The buffer from which the executor was invoked.
+        {env?}    (table<string, string>)
+                             The environment variables to set for the command.
 
 
 rustaceanvim.FloatWinConfig                        *rustaceanvim.FloatWinConfig*

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -114,6 +114,8 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---
 ---The buffer from which the executor was invoked.
 ---@field bufnr? integer
+---The environment variables to set for the command.
+---@field env? table<string, string>
 
 ---@class rustaceanvim.FloatWinConfig
 ---@field auto_focus? boolean

--- a/lua/rustaceanvim/executors/background.lua
+++ b/lua/rustaceanvim/executors/background.lua
@@ -28,7 +28,7 @@ M.execute_command = function(command, args, cwd, opts)
   local notify_prefix = (is_single_test and 'test ' or 'tests ')
   local cmd = vim.list_extend({ command }, args)
   local fname = vim.api.nvim_buf_get_name(opts.bufnr)
-  vim.system(cmd, { cwd = cwd }, function(sc)
+  vim.system(cmd, { cwd = cwd, env = opts.env }, function(sc)
     ---@cast sc vim.SystemCompleted
     if sc.code == 0 then
       local summary = get_test_summary(sc.stdout or '')

--- a/lua/rustaceanvim/executors/quickfix.lua
+++ b/lua/rustaceanvim/executors/quickfix.lua
@@ -20,7 +20,7 @@ end
 
 ---@type rustaceanvim.Executor
 local M = {
-  execute_command = function(command, args, cwd, _)
+  execute_command = function(command, args, cwd, opts)
     -- open quickfix
     copen()
     -- go back to the previous window
@@ -32,7 +32,7 @@ local M = {
     local cmd = vim.list_extend({ command }, args)
     vim.system(
       cmd,
-      cwd and { cwd = cwd } or {},
+      { cwd = cwd, env = opts.env },
       vim.schedule_wrap(function(sc)
         ---@cast sc vim.SystemCompleted
         local data = ([[

--- a/lua/rustaceanvim/executors/termopen.lua
+++ b/lua/rustaceanvim/executors/termopen.lua
@@ -3,7 +3,7 @@ local latest_buf_id = nil
 
 ---@type rustaceanvim.Executor
 local M = {
-  execute_command = function(command, args, cwd, _)
+  execute_command = function(command, args, cwd, opts)
     local shell = require('rustaceanvim.shell')
     local ui = require('rustaceanvim.ui')
     local commands = {}
@@ -29,7 +29,7 @@ local M = {
     -- close the buffer when escape is pressed :)
     vim.keymap.set('n', '<Esc>', '<CMD>q<CR>', { buffer = latest_buf_id, noremap = true })
 
-    vim.fn.jobstart(full_command, { term = true })
+    vim.fn.jobstart(full_command, { term = true, env = opts.env })
 
     -- when the buffer is closed, set the latest buf id to nil else there are
     -- some edge cases with the id being sit but a buffer not being open

--- a/lua/rustaceanvim/executors/toggleterm.lua
+++ b/lua/rustaceanvim/executors/toggleterm.lua
@@ -1,6 +1,6 @@
 ---@type rustaceanvim.Executor
 local M = {
-  execute_command = function(command, args, cwd, _)
+  execute_command = function(command, args, cwd, opts)
     local ok, term = pcall(require, 'toggleterm.terminal')
     if not ok then
       vim.schedule(function()
@@ -13,6 +13,7 @@ local M = {
     term.Terminal
       :new({
         dir = cwd,
+        env = opts.env,
         cmd = shell.make_command_from_args(command, args),
         close_on_exit = false,
         on_open = function(t)

--- a/lua/rustaceanvim/executors/vimux.lua
+++ b/lua/rustaceanvim/executors/vimux.lua
@@ -2,14 +2,18 @@ local shell = require('rustaceanvim.shell')
 
 ---@type rustaceanvim.Executor
 local M = {
-  execute_command = function(command, args, cwd, _)
+  execute_command = function(command, args, cwd, opts)
+    local envs = ''
+    for k, v in pairs(opts.env) do
+      envs = envs .. k .. "='" .. v .. "' "
+    end
     local commands = {}
     if cwd then
       table.insert(commands, shell.make_cd_command(cwd))
     end
     table.insert(commands, shell.make_command_from_args(command, args))
     local full_command = shell.chain_commands(commands)
-    vim.fn.VimuxRunCommand(full_command)
+    vim.fn.VimuxRunCommand(envs .. full_command)
   end,
 }
 

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -269,7 +269,7 @@ function NeotestAdapter.build_spec(run_args)
     type = pos.type,
     tree = tree,
   }
-  local exe, args, cwd = require('rustaceanvim.runnables').get_command(runnable)
+  local exe, args, cwd, env = require('rustaceanvim.runnables').get_command(runnable)
   if run_args.strategy == 'dap' then
     local dap = require('rustaceanvim.dap')
     overrides.sanitize_command_for_debugging(runnable.args.cargoArgs)
@@ -313,6 +313,7 @@ function NeotestAdapter.build_spec(run_args)
     command = vim.list_extend({ exe }, args),
     cwd = cwd,
     context = context,
+    env = env,
   }
   return run_spec
 end


### PR DESCRIPTION
Closes #770.

@mrcjkb Thanks for marking #770 as a good first issue! As a novice in Neovim plugin development, I decided to give it a shot. Please feel free to provide suggestions on how I may improve this patch, and many thanks in advance 🙏 

I cannot say for all backends, but at least the `nextest` backend is known to work with this patch according to my manual testing.