### PR TITLE
fix: improve Mason 2.0 compatibility for codelldb adapter

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -336,10 +336,12 @@ local RustaceanDefaultConfig = {
       if has_mason and mason_registry.is_installed('codelldb') then
         local codelldb_package = mason_registry.get_package('codelldb')
         local mason_codelldb_path
-        if require('mason.version').MAJOR_VERSION > 1 then
-          mason_codelldb_path = vim.fs.joinpath(vim.fn.expand('$MASON'), 'packages', codelldb_package.name, 'extension')
-        else
+        -- Check if get_install_path method exists (pre-2.0 Mason API)
+        if codelldb_package.get_install_path then
           mason_codelldb_path = vim.fs.joinpath(codelldb_package:get_install_path(), 'extension')
+        else
+          -- Use new Mason 2.0+ API structure
+          mason_codelldb_path = vim.fs.joinpath(vim.fn.expand('$MASON'), 'packages', codelldb_package.name, 'extension')
         end
         local codelldb_path = vim.fs.joinpath(mason_codelldb_path, 'adapter', 'codelldb')
         local liblldb_path = vim.fs.joinpath(mason_codelldb_path, 'lldb', 'lib', 'liblldb')


### PR DESCRIPTION
## Summary

Fixes #782 by improving Mason 2.0 compatibility for the codelldb DAP adapter setup.

- Replace version check with method existence check for better compatibility with Mason API changes
- The `get_install_path()` method was removed in Mason 2.0, causing runtime errors
- Now checks if the method exists before calling it, falling back to the new API structure

## Changes

- Modified `lua/rustaceanvim/config/internal.lua` to use method existence check instead of version comparison
- Maintains backward compatibility with Mason 1.x while supporting Mason 2.0+

## Background

Mason 2.0 introduced breaking changes as documented in their [changelog](https://github.com/mason-org/mason.nvim/blob/8024d64e1330b86044fed4c8494ef3dcd483a67c/CHANGELOG.md?plain=1#L65):

> `Package:get_install_path()` has been removed. Use `vim.fs.joinpath(package.install_path)` instead.

The previous implementation relied on version checking which could fail in edge cases. This approach is more robust as it directly checks for the method's availability.

## Testing

- Tested the logical flow of the conditional check
- Maintains compatibility with both Mason API versions
- No breaking changes to existing functionality