### PR TITLE
fix(ui): unset foldcolumn in grouped code actions

### DIFF
--- a/lua/rustaceanvim/commands/code_action_group.lua
+++ b/lua/rustaceanvim/commands/code_action_group.lua
@@ -184,6 +184,7 @@ local function on_code_action_results(results, ctx)
     col = 0,
   })
   vim.wo[primary_winnr].signcolumn = 'no'
+  vim.wo[primary_winnr].foldcolumn = '0'
   M.state.primary.winnr = primary_winnr
 
   local idx = 1


### PR DESCRIPTION
For quite a while I've been dealing with the "Grouped code actions" windows cutting off the last couple characters 
in the options from the secondary window, and I finally got around to looking into it.

Given the following minimal rust file:

```rs
fn main() {
    let _x = 42;
}
```
when placing the cursor on the `42` and triggering `:lua vim.cmd.RustLsp('codeAction')`, I get the following:
![image](https://github.com/user-attachments/assets/f8c70bf4-dae8-49fa-ac7c-4c79ae1d6a59)

After some poking around, I finally realized it was from me setting `foldcolumn='3'` in my config. After running
`:set foldcolumn='0'`, I get the following in the grouped code actions:

![image](https://github.com/user-attachments/assets/069a2aa8-24e2-43b5-9145-134d5f2166ae)

I'll also point out that I have `numberwidth=4` in my config as well which results in there being 2 spaces between the
border and the line number instead of just 1, which one could argue would look better, but since clearing `foldcolumn`
fixes the issue at hand I've left that out. I'd be happy to add a setting for that to this PR as well if you want, but setting
it manually when I have the menu active doesn't seem to have any effect with the minimal config, so that may be
something more specific to my regular setup.

I've also tested this with a minimal config to confirm foldcolumn is responsible for this and not something else:

`nvim -u minimal.lua src/main.rs -c 'set foldcolumn=3'` results in similar behavior, with the difference being the text wraps
instead of being hidden, which also isn't ideal:
![image](https://github.com/user-attachments/assets/7133be67-71d8-4b35-a084-98352a8dd080)


<details>
<summary>minimal.lua</summary>

The `minimal.lua` in the repo didn't quite work for me as-is, so I copied the bootstrap
chunk from my own config:

```lua
vim.env.LAZY_STDPATH = '.repro'

-- Bootstrap lazy.nvim
local lazypath = ".repro"
if not (vim.uv or vim.loop).fs_stat(lazypath) then
    local lazyrepo = "https://github.com/folke/lazy.nvim.git"
    local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
    if vim.v.shell_error ~= 0 then
        vim.api.nvim_echo({
            { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
            { out, "WarningMsg" },
            { "\nPress any key to exit..." },
        }, true, {})
        vim.fn.getchar()
        os.exit(1)
    end
end
vim.opt.rtp:prepend(lazypath)


require('lazy.minit').repro {
  spec = {
    {
      'mrcjkb/rustaceanvim',
      version = '^6',
      init = function()
        -- Configure rustaceanvim here
        vim.g.rustaceanvim = {}
      end,
      lazy = false,
    },
  },
}
```
</details>