### PR TITLE
fix(dap): refine the error message when a debug adapter can not be found

### DIFF
--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -284,7 +284,7 @@ function M.start(args, verbose, callback, on_error)
   local adapter = types.evaluate(config.dap.adapter)
   --- @cast adapter rustaceanvim.dap.executable.Config | rustaceanvim.dap.server.Config | rustaceanvim.disable
   if adapter == false then
-    on_error('Debug adapter is disabled.')
+    on_error('Debug adapter is not installed or found.')
     return
   end
 

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -281,18 +281,24 @@ function NeotestAdapter.build_spec(run_args)
       future.set_error(err)
     end)
     local ok, strategy = pcall(future.wait)
+    local run_spec
     if not ok then
       ---@cast strategy string
       lib.notify(strategy, vim.log.levels.ERROR)
+      run_spec = {
+        cwd = cwd,
+        context = context,
+      }
+    else
+      ---@cast strategy rustaceanvim.dap.client.Config
+      ---@type rustaceanvim.neotest.RunSpec
+      ---@diagnostic disable-next-line
+      run_spec = {
+        cwd = cwd,
+        context = context,
+        strategy = strategy,
+      }
     end
-    ---@cast strategy rustaceanvim.dap.client.Config
-    ---@type rustaceanvim.neotest.RunSpec
-    ---@diagnostic disable-next-line
-    local run_spec = {
-      cwd = cwd,
-      context = context,
-      strategy = strategy,
-    }
     return run_spec
   else
     overrides.undo_debug_sanitize(runnable.args.cargoArgs)


### PR DESCRIPTION
According to the neotest documentation, the `strategy` should be a `table` or a function. Current implementation returns a string as the `straetegy` value. See image below in case I forgot to install the codelldb debug adapter.

![image](https://github.com/user-attachments/assets/4bce41cf-80d3-4598-84a0-6dea28b158d0)


This commit fixes the implementation and refines the error message.
After this fix, the user will see the error message as:

![image](https://github.com/user-attachments/assets/33618706-6081-4657-888f-eea9b5f9fab7)

when the debug adapter is not installed.