### PR TITLE
feat(lsp): `experimental/localDocs` support

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -92,6 +92,7 @@ It accepts the following subcommands:
                         the quickfix list.
  'openCargo' - Open the Cargo.toml file for the current package.
  'openDocs' - Open docs.rs documentation for the symbol under the cursor.
+	      If documentation exists locally, open it instead.
  'parentModule' - Open the current module's parent module.
  'workspaceSymbol {onlyTypes?|allSymbols?} {query?}'
                   Filtered workspace symbol search.

--- a/lua/rustaceanvim/commands/external_docs.lua
+++ b/lua/rustaceanvim/commands/external_docs.lua
@@ -10,7 +10,13 @@ function M.open_external_docs()
     0,
     'experimental/externalDocs',
     vim.lsp.util.make_position_params(0, clients[1].offset_encoding or 'utf-8'),
-    function(_, url)
+    function(_, response)
+      local url
+      if response['local'] and vim.uv.fs_stat(vim.uri_to_fname(response['local'])) then
+        url = response['local']
+      else
+        url = response.web
+      end
       if url then
         local config = require('rustaceanvim.config.internal')
         config.tools.open_url(url)

--- a/lua/rustaceanvim/config/server.lua
+++ b/lua/rustaceanvim/config/server.lua
@@ -52,6 +52,7 @@ function server.create_client_capabilities()
     snippetTextEdit = true,
     codeActionGroup = true,
     ssr = true,
+    localDocs = true,
   }
 
   -- enable auto-import


### PR DESCRIPTION
I opened #805 yesterday. Turns out, it's really not rocket science to implement.

I am worried about HTML URIs potentially being handled by a text editor, though.
Also, we're implicitly relying on outdated documentation for local types, as there's nothing that rebuilds it on save. It is still better than a 404 page, I think.
And I sure hope all 4 opening strategies can handle `file://` identifiers.

I couldn't properly run `luarocks` tests.