### PR TITLE
docs: adapt docs to appear under `:help local-additions`

### DIFF
--- a/doc/mason.txt
+++ b/doc/mason.txt
@@ -1,5 +1,5 @@
+*rustaceanvim.mason*                          mason-lspconfig troubleshooting
 ==============================================================================
-mason-lspconfig troubleshooting                          *rustaceanvim.mason*
 
 This plugin supports automatically detecting mason.nvim codelldb installations,
 but not rust-analyzer.

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -1,3 +1,4 @@
+*rustaceanvim.txt*           RustaceanVim - A Neovim plugin for Rust development
 ==============================================================================
 Table of Contents                                        *rustaceanvim.contents*
 


### PR DESCRIPTION
The documentation for vim help pages states that a first line is required for the file to appear under `:help local-additions`, with the following format: `*tag* description`

This change adapts the doc files to that format