### PR TITLE
feat: suppprt to enable or disable ![cfg(test)]

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -32,6 +32,8 @@ Commands:
  The ':RustAnalyzer target' command can take a valid rustc target,
  such as 'wasm32-unknown-unknown', or it can be left empty to set the LSP client
  to use the default target architecture for the operating system.
+ ':RustAnalyzer cfgTest <boolean>' - Enable or disable ![cfg(test)].
+
 
 The ':RustLsp[!]' command is available after the LSP client has initialized.
 It accepts the following subcommands:

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -21,6 +21,7 @@
 ---                                      Takes a Lua table as an argument.
 ---                                      Example: `:RustAnalyzer config { checkOnSave = false }`
 ---                                      WARNING: This command does not validate the Lua config table.
+--- ':RustAnalyzer cfgTest <boolean>' - Enable or disable ![cfg(test)].
 
 --- The ':RustAnalyzer target' command can take a valid rustc target,
 --- such as 'wasm32-unknown-unknown', or it can be left empty to set the LSP client


### PR DESCRIPTION
See: https://rust-analyzer.github.io/book/configuration#cfg.setTest

This is useful to switch `![cfg(test)]` when develop like:

https://github.com/tokio-rs/tokio/blob/4b96af6040b0136d3fd147b28e3775961f6a3d0a/tokio/src/fs/mod.rs#L280:L281