### PR TITLE
fix(help): Add tags for commands

### DIFF
--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -20,6 +20,7 @@ and integrates with other rust tools.
 
 Commands:
 
+                                                                 *:RustAnalyzer*
  ':RustAnalyzer start' - Start the LSP client.
  ':RustAnalyzer stop' - Stop the LSP client.
  ':RustAnalyzer restart' - Restart the LSP client.
@@ -33,6 +34,7 @@ Commands:
  such as 'wasm32-unknown-unknown', or it can be left empty to set the LSP client
  to use the default target architecture for the operating system.
 
+                                                                      *:RustLsp*
 The ':RustLsp[!]' command is available after the LSP client has initialized.
 It accepts the following subcommands:
 
@@ -115,6 +117,7 @@ It accepts the following subcommands:
               Defaults to `flyCheck run` if called without an argument.
  'logFile' - Open the rust-analyzer log file.
 
+                                                                        *:Rustc*
 The ':Rustc' command can be used to interact with rustc.
 It accepts the following subcommands:
 


### PR DESCRIPTION
This makes `:h :RustAnalyzer` work