### PR TITLE
build: add missing `copy_directories` to lux.toml

### DIFF
--- a/lux.toml
+++ b/lux.toml
@@ -13,6 +13,10 @@ license = "GPL-2.0-only"
 
 [build]
 type = "builtin"
+copy_directories = [
+  "doc",
+  "ftplugin"
+]
 
 [test]
 type = "busted-nlua"

--- a/rustaceanvim-dev-1.rockspec
+++ b/rustaceanvim-dev-1.rockspec
@@ -29,10 +29,10 @@ source = {
 	url = "git+https://github.com/mrcjkb/rustaceanvim.git",
 }
 
-test = {
-	type = "busted-nlua",
-}
-
 build = {
 	type = "builtin",
+	copy_directories = {
+		"doc",
+		"ftplugin",
+	},
 }


### PR DESCRIPTION
Fixes #895 