### PR TITLE
refactor api call that will be deprecated

### DIFF
--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -49,7 +49,7 @@ see ':h rustaceanvim.lsp.ClientOpts'.
   -- This workaround forces Neovim to redraw inlay hints if they are enabled,
   -- as soon as rust-analyzer has fully initialized.
   if type(vim.lsp.inlay_hint) == 'table' then
-    for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
+    for _, bufnr in ipairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers) do
       if vim.lsp.inlay_hint.is_enabled { bufnr = bufnr } then
         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
         vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })


### PR DESCRIPTION
Fixes this `checkhealth issue`:
```
- ⚠️ WARNING vim.lsp.get_buffers_by_client_id() is deprecated. Feature will be removed in Nvim 0.13
  - ADVICE:
    - use vim.lsp.get_client_by_id(id).attached_buffers instead.
    - stack traceback:
        ~/.local/share/nvim/site/pack/core/opt/rustaceanvim/lua/rustaceanvim/server_status.lua:52
        ~/.local/share/bob/nightly/share/nvim/runtime/lua/vim/lsp/client.lua:1194
        ~/.local/share/bob/nightly/share/nvim/runtime/lua/vim/lsp/client.lua:449
        vim/_editor.lua:0
```

Note that I'm currently on the nightly build of Neovim