### PR TITLE
feat!: drop ra-multiplex support in favour of lspmux

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,14 +756,14 @@ by setting the rust-analyzer
 
 <details>
   <summary>
-  <b>ra-multiplex</b>
+  <b>lspmux</b>
   </summary>
 
   On Linux and MacOS, rustaceanvim can auto-detect and connect to a
-  running [ra-multiplex](https://github.com/pr2502/ra-multiplex) server.
+  running [lspmux](https://codeberg.org/p2502/lspmux) server.
   By default, it will try to do so automatically if the `vim.g.rustaceanvim.server.cmd`
   option is unset.
-  See also `:h rustaceanvim.ra_multiplex`.
+  See also `:h rustaceanvim.lspmux`.
 
 </details>
 

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -313,28 +313,28 @@ rustaceanvim.rustc.Opts                                *rustaceanvim.rustc.Opts*
 rustaceanvim.lsp.ClientOpts                        *rustaceanvim.lsp.ClientOpts*
 
     Fields: ~
-        {auto_attach?}   (boolean|fun(bufnr:integer):boolean)
-                                                                                                                      Whether to automatically attach the LSP client.
-                                                                                                                      Defaults to `true` if the `rust-analyzer` executable is found.
-        {cmd?}           (string[]|fun():string[]|fun(dispatchers:vim.lsp.rpc.Dispatchers):vim.lsp.rpc.PublicClient)
-                                                                                                                      Command and arguments for starting rust-analyzer
-                                                                                                                      Can be a list of arguments, a function that returns a list of arguments,
-                                                                                                                      or a function that returns an LSP RPC client factory (see |vim.lsp.rpc.connect|).
-        {root_dir?}      (string|fun(filename:string,default:fun(filename:string):string|nil):string|nil)
-                                                                                                                      The directory to use for the attached LSP.
-                                                                                                                      Can be a function, which may return nil if no server should attach.
-                                                                                                                      The second argument contains the default implementation, which can be used for fallback behavior.
-        {ra_multiplex?}  (rustaceanvim.ra_multiplex.Opts)
-                                                                                                                      Options for connecting to ra-multiplex.
+        {auto_attach?}  (boolean|fun(bufnr:integer):boolean)
+                                                                                                                     Whether to automatically attach the LSP client.
+                                                                                                                     Defaults to `true` if the `rust-analyzer` executable is found.
+        {cmd?}          (string[]|fun():string[]|fun(dispatchers:vim.lsp.rpc.Dispatchers):vim.lsp.rpc.PublicClient)
+                                                                                                                     Command and arguments for starting rust-analyzer
+                                                                                                                     Can be a list of arguments, a function that returns a list of arguments,
+                                                                                                                     or a function that returns an LSP RPC client factory (see |vim.lsp.rpc.connect|).
+        {root_dir?}     (string|fun(filename:string,default:fun(filename:string):string|nil):string|nil)
+                                                                                                                     The directory to use for the attached LSP.
+                                                                                                                     Can be a function, which may return nil if no server should attach.
+                                                                                                                     The second argument contains the default implementation, which can be used for fallback behavior.
+        {lspmux?}       (rustaceanvim.lspmux.Opts)
+                                                                                                                     Options for connecting to lspmux.
 
 
-rustaceanvim.ra_multiplex.Opts                  *rustaceanvim.ra_multiplex.Opts*
+rustaceanvim.lspmux.Opts                              *rustaceanvim.lspmux.Opts*
 
     Fields: ~
         {enable?}  (boolean)
-                              Whether to enable ra-multiplex auto-discovery.
+                              Whether to enable lspmux auto-discovery.
                               Default: `true` if `server.cmd` is not set, otherwise `false`.
-                              If enabled, rustaceanvim will try to detect if an ra-multiplex server is running
+                              If enabled, rustaceanvim will try to detect if an lspmux server is running
                               and connect to it (Linux and MacOS only).
                               If auto-discovery does not work, you can set `server.cmd` to a function that
                               returns an LSP RPC client factory (see |vim.lsp.rpc.connect|).

--- a/doc/tags
+++ b/doc/tags
@@ -33,9 +33,9 @@ rustaceanvim.executor_alias	rustaceanvim.txt	/*rustaceanvim.executor_alias*
 rustaceanvim.intro	rustaceanvim.txt	/*rustaceanvim.intro*
 rustaceanvim.lsp.ClientOpts	rustaceanvim.txt	/*rustaceanvim.lsp.ClientOpts*
 rustaceanvim.lsp_server_health_status	rustaceanvim.txt	/*rustaceanvim.lsp_server_health_status*
+rustaceanvim.lspmux.Opts	rustaceanvim.txt	/*rustaceanvim.lspmux.Opts*
 rustaceanvim.mason	mason.txt	/*rustaceanvim.mason*
 rustaceanvim.neotest	rustaceanvim.txt	/*rustaceanvim.neotest*
-rustaceanvim.ra_multiplex.Opts	rustaceanvim.txt	/*rustaceanvim.ra_multiplex.Opts*
 rustaceanvim.rustc.Opts	rustaceanvim.txt	/*rustaceanvim.rustc.Opts*
 rustaceanvim.server.status_notify_level	rustaceanvim.txt	/*rustaceanvim.server.status_notify_level*
 rustaceanvim.test_executor_alias	rustaceanvim.txt	/*rustaceanvim.test_executor_alias*

--- a/lua/rustaceanvim/config/check.lua
+++ b/lua/rustaceanvim/config/check.lua
@@ -19,7 +19,7 @@ local M = {}
 ---@return string|nil error_message
 local function validate(name, value, validator, optional, message)
   local ok, err = pcall(vim.validate, name, value, validator, optional, message)
-  return ok or false, 'Rocks: Invalid config' .. (err and ': ' .. err or '')
+  return ok or false, 'rustaceanvim: Invalid config' .. (err and ': ' .. err or '')
 end
 
 ---Validates the config.

--- a/lua/rustaceanvim/config/init.lua
+++ b/lua/rustaceanvim/config/init.lua
@@ -197,8 +197,8 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---The second argument contains the default implementation, which can be used for fallback behavior.
 ---@field root_dir? string | fun(filename: string, default: fun(filename: string):string|nil):string|nil
 ---
----Options for connecting to ra-multiplex.
----@field ra_multiplex? rustaceanvim.ra_multiplex.Opts
+---Options for connecting to lspmux.
+---@field lspmux? rustaceanvim.lspmux.Opts
 ---
 ---Setting passed to rust-analyzer.
 ---By default, this is a function that configures rust-analyzer
@@ -230,11 +230,11 @@ vim.g.rustaceanvim = vim.g.rustaceanvim
 ---
 ---@see vim.lsp.ClientConfig
 
----@class rustaceanvim.ra_multiplex.Opts
+---@class rustaceanvim.lspmux.Opts
 ---
----Whether to enable ra-multiplex auto-discovery.
+---Whether to enable lspmux auto-discovery.
 ---Default: `true` if `server.cmd` is not set, otherwise `false`.
----If enabled, rustaceanvim will try to detect if an ra-multiplex server is running
+---If enabled, rustaceanvim will try to detect if an lspmux server is running
 ---and connect to it (Linux and MacOS only).
 ---If auto-discovery does not work, you can set `server.cmd` to a function that
 ---returns an LSP RPC client factory (see |vim.lsp.rpc.connect|).

--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -288,7 +288,7 @@ local RustaceanDefaultConfig = {
     ---@type nil | string | fun(filename: string, default: fun(filename: string):string|nil):string|nil
     root_dir = nil,
 
-    ra_multiplex = {
+    lspmux = {
       ---@type boolean
       enable = vim.tbl_get(rustaceanvim_opts, 'server', 'cmd') == nil,
       ---@type string

--- a/lua/rustaceanvim/health.lua
+++ b/lua/rustaceanvim/health.lua
@@ -236,9 +236,9 @@ function health.check()
       end,
     },
     {
-      name = 'ra-multiplex',
+      name = 'lspmux',
       get_binaries = function()
-        return { 'ra-multiplex' }
+        return { 'lspmux' }
       end,
       is_installed = function(bin)
         local success = pcall(function()
@@ -249,7 +249,7 @@ function health.check()
       is_optional = function()
         return true
       end,
-      url = '[ra-multiplex](https://github.com/pr2502/ra-multiplex)',
+      url = '[lspmux](https://codeberg.org/p2502/lspmux)',
       info = 'Multiplex server for rust-analyzer.',
     },
     {

--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -209,14 +209,14 @@ Starting rust-analyzer client in detached/standalone mode (with reduced function
 
     local rust_analyzer_cmd = types.evaluate(client_config.cmd)
 
-    local ra_multiplex = lsp_start_config.ra_multiplex
-    if ra_multiplex.enable then
-      local ok, running_ra_multiplex = pcall(function()
-        local result = vim.system({ 'pgrep', 'ra-multiplex' }):wait().code
+    local lspmux = lsp_start_config.lspmux
+    if lspmux.enable then
+      local ok, running_lspmux = pcall(function()
+        local result = vim.system({ 'pgrep', 'lspmux' }):wait().code
         return result == 0
       end)
-      if ok and running_ra_multiplex then
-        rust_analyzer_cmd = vim.lsp.rpc.connect(ra_multiplex.host, ra_multiplex.port)
+      if ok and running_lspmux then
+        rust_analyzer_cmd = vim.lsp.rpc.connect(lspmux.host, lspmux.port)
         local ra_settings = lsp_start_config.settings['rust-analyzer'] or {}
         ra_settings.lspMux = ra_settings.lspMux
           or {


### PR DESCRIPTION
ra-multiplex is no longer maintained. It has been replaced with lspmux, which is more generic.