### PR TITLE
tests(parser): add golden tests for cargo and nextest outputs

### DIFF
--- a/spec/neotest_spec.lua
+++ b/spec/neotest_spec.lua
@@ -3,34 +3,36 @@ local parser = require('rustaceanvim.neotest.parser')
 ---@param fixture string
 local function run_golden_test_cargo(fixture)
   ---@diagnostic disable-next-line: missing-fields
-  local results = parser.populate_pass_positions_cargo_test({}, { file = 'test_file.rs' }, fixture)
+  local results = parser.populate_pass_positions_cargo_test(
+    {},
+    { file = 'test_file.rs' },
+    fixture
+  )
+
   assert.same({
-    ['test_file.rs::test_ok'] = {
-      status = 'passed',
-    },
-    ['test_file.rs::test_ok2'] = {
-      status = 'passed',
-    },
+    ['test_file.rs::test_ok'] = { status = 'passed' },
+    ['test_file.rs::test_ok2'] = { status = 'passed' },
   }, results)
 end
 
+---@param fixture string
 local function run_golden_test_nextest(fixture)
   ---@diagnostic disable-next-line: missing-fields
-  local results = parser.populate_pass_positions_nextest({}, { file = 'test_file.rs' }, fixture)
+  local results = parser.populate_pass_positions_nextest(
+    {},
+    { file = 'test_file.rs' },
+    fixture
+  )
+
   assert.same({
-    ['test_file.rs::test_ok'] = {
-      status = 'passed',
-    },
-    ['test_file.rs::test_ok2'] = {
-      status = 'passed',
-    },
+    ['test_file.rs::test_ok'] = { status = 'passed' },
+    ['test_file.rs::test_ok2'] = { status = 'passed' },
   }, results)
 end
 
 describe('rustaceanvim.neotest', function()
   describe('parser', function()
     it('passing tests in cargo output', function()
-      --
       local fixture = [[
     Finished `test` profile [unoptimized + debuginfo] target(s) in 0.00s
      Running unittests src/lib.rs (target/debug/deps/rustaceanvim_460_repro-9a70619d0810014e)
@@ -64,7 +66,6 @@ assertion `left == right` failed
  right: 2
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
-
 failures:
     test_external_fail
     test_external_fail2
@@ -75,6 +76,7 @@ error: test failed, to rerun pass `--test repro`
 ]]
       run_golden_test_cargo(fixture)
     end)
+
     it('passing tests in cargo-nextest junit output', function()
       local fixture = [[
 <?xml version="1.0" encoding="UTF-8"?>
@@ -90,8 +92,9 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; fini
 </system-out>
             <system-err></system-err>
         </testcase>
+
         <testcase name="test_external_fail" classname="rustaceanvim-460-repro::repro" timestamp="2025-08-15T17:31:44.287+01:00" time="0.005">
-            <failure message="thread &apos;test_external_fail&apos; panicked at src/lib.rs:2:5" type="test failure">thread &apos;test_external_fail&apos; panicked at src/lib.rs:2:5:
+            <failure message="thread 'test_external_fail' panicked at src/lib.rs:2:5" type="test failure">thread 'test_external_fail' panicked at src/lib.rs:2:5:
 assertion `left == right` failed
   left: 1
  right: 2
@@ -101,21 +104,20 @@ running 1 test
 test test_external_fail ... FAILED
 
 failures:
-
-failures:
     test_external_fail
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
 
 </system-out>
             <system-err>
-thread &apos;test_external_fail&apos; panicked at src/lib.rs:2:5:
+thread 'test_external_fail' panicked at src/lib.rs:2:5:
 assertion `left == right` failed
   left: 1
  right: 2
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 </system-err>
         </testcase>
+
         <testcase name="test_ok2" classname="rustaceanvim-460-repro::repro" timestamp="2025-08-15T17:31:44.287+01:00" time="0.005">
             <system-out>
 running 1 test
@@ -126,8 +128,9 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; fini
 </system-out>
             <system-err></system-err>
         </testcase>
+
         <testcase name="test_external_fail2" classname="rustaceanvim-460-repro::repro" timestamp="2025-08-15T17:31:44.287+01:00" time="0.005">
-            <failure message="thread &apos;test_external_fail2&apos; panicked at src/lib.rs:2:5" type="test failure">thread &apos;test_external_fail2&apos; panicked at src/lib.rs:2:5:
+            <failure message="thread 'test_external_fail2' panicked at src/lib.rs:2:5" type="test failure">thread 'test_external_fail2' panicked at src/lib.rs:2:5:
 assertion `left == right` failed
   left: 1
  right: 2
@@ -137,15 +140,13 @@ running 1 test
 test test_external_fail2 ... FAILED
 
 failures:
-
-failures:
     test_external_fail2
 
 test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s
 
 </system-out>
             <system-err>
-thread &apos;test_external_fail2&apos; panicked at src/lib.rs:2:5:
+thread 'test_external_fail2' panicked at src/lib.rs:2:5:
 assertion `left == right` failed
   left: 1
  right: 2
@@ -154,7 +155,6 @@ note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
         </testcase>
     </testsuite>
 </testsuites>
-
 ]]
       run_golden_test_nextest(fixture)
     end)


### PR DESCRIPTION
Adds golden tests for the neotest parser to validate cargo and nextest output handling.

- Adds cargo output golden test (passing & failing cases)
- Adds nextest JUnit output golden test
- Ensures parser returns consistent pass positions for both runners

Improves reliability of test detection logic in rustaceanvim.