### PR TITLE
fix(dap): use console instead of runInTerminal for lldb-dap

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -57,7 +57,7 @@ local function load_dap_configuration(type)
   }
   if type == 'lldb' then
     ---@diagnostic disable-next-line: inject-field
-    dap_config.runInTerminal = true
+    dap_config.console = 'integratedTerminal'
   end
   ---@diagnostic disable-next-line: different-requires
   local dap = require('dap')


### PR DESCRIPTION
Follow up #494.

`runInTerminal` is deprecated. It is recommended to use `console` instead.

References:
- [LLDB DAP README](https://github.com/llvm/llvm-project/blob/main/lldb/tools/lldb-dap/README.md)
- Related PR: [Commit 9098bff](https://github.com/llvm/llvm-project/commit/9098bffb0370273e67c76ab996eb4559dcc71f34)