### PR TITLE
feat: `RustLsp relatedTests` command (#779)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,24 @@ vim.keymap.set(
 
 <details>
   <summary>
+  <b>Related tests</b>
+  </summary>
+
+Query rust-analyzer for tests associated with the symbol under
+the cursor (or its enclosing function) and quickly jump to one.
+
+```vim
+:RustLsp relatedTests
+```
+
+```lua
+vim.cmd.RustLsp('relatedTests')
+```
+
+</details>
+
+<details>
+  <summary>
   <b>Open Cargo.toml</b>
   </summary>
 

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -49,6 +49,7 @@ It accepts the following subcommands:
  'testables {args[]}?' - Run tests
                          ':RustLsp!' means run the last testable (ignores any args).
                          `args[]` allows you to override the executable's arguments.
+ 'relatedTests'        - Open the tests rust-analyzer associates with the symbol under the cursor.
  'expandMacro' - Expand macros recursively.
  'moveItem {up|down}' - Move items up or down.
  'codeAction' - Sometimes, rust-analyzer groups code actions by category,

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -89,6 +89,11 @@ local rustlsp_command_tbl = {
       require('rustaceanvim.commands.diagnostic').related_diagnostics()
     end,
   },
+  relatedTests = {
+    impl = function()
+      require('rustaceanvim.commands.related_tests').related_tests()
+    end,
+  },
   renderDiagnostic = {
     impl = function(args)
       local subcmd = args[1] or 'cycle'

--- a/lua/rustaceanvim/commands/related_tests.lua
+++ b/lua/rustaceanvim/commands/related_tests.lua
@@ -1,0 +1,65 @@
+local ra = require('rustaceanvim.rust_analyzer')
+local rts = require('rustaceanvim.treesitter')
+
+local M = {}
+
+---@class rustaceanvim.RATestInfo
+---@field runnable rustaceanvim.RARunnable
+
+---@param offset_encoding string
+---@return lsp.TextDocumentPositionParams
+local function get_params(offset_encoding)
+  local position_params = vim.lsp.util.make_position_params(0, offset_encoding)
+
+  if rts.has_tree_sitter_rust() then
+    local fn_identifier_position = rts.find_fn_identifier_position()
+    if fn_identifier_position ~= nil then
+      position_params.position = fn_identifier_position
+    end
+  end
+
+  return position_params
+end
+
+---@param offset_encoding string
+---@return lsp.Handler See |lsp-handler|
+local function mk_handler(offset_encoding)
+  ---@param tests? rustaceanvim.RATestInfo[]
+  return function(_, tests)
+    if tests == nil then
+      -- this can be nil when LSP has not finished loading
+      return
+    end
+
+    local test_locations = {}
+    for _, test in ipairs(tests) do
+      table.insert(test_locations, test.runnable.location)
+    end
+
+    if #test_locations == 0 then
+      return
+    elseif #test_locations == 1 then
+      vim.lsp.util.show_document(test_locations[1], offset_encoding, { reuse_win = true, focus = true })
+      return
+    else
+      local quickfix_entries = vim.lsp.util.locations_to_items(test_locations, offset_encoding)
+      vim.fn.setqflist({}, ' ', { title = 'related tests', items = quickfix_entries })
+      vim.cmd([[ botright copen ]])
+    end
+  end
+end
+
+---@return nil
+function M.related_tests()
+  local clients = ra.get_active_rustaceanvim_clients(0)
+  if #clients == 0 then
+    return
+  end
+
+  local offset_encoding = clients[1].offset_encoding or 'utf-8'
+
+  local params = get_params(offset_encoding)
+  ra.buf_request(0, 'rust-analyzer/relatedTests', params, mk_handler(offset_encoding))
+end
+
+return M

--- a/lua/rustaceanvim/commands/rustc_unpretty.lua
+++ b/lua/rustaceanvim/commands/rustc_unpretty.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local cargo = require('rustaceanvim.cargo')
 local ui = require('rustaceanvim.ui')
+local rts = require('rustaceanvim.treesitter')
 local api = vim.api
 local ts = vim.treesitter
 
@@ -93,15 +94,9 @@ local function handler(sc)
   vim.api.nvim_buf_set_lines(latest_buf_id, 0, 0, false, lines)
 end
 
----@return boolean
-local function has_tree_sitter_rust()
-  return #api.nvim_get_runtime_file('parser/rust.so', true) > 0
-    or require('rustaceanvim.shell').is_windows() and #api.nvim_get_runtime_file('parser/rust.dll', true) > 0
-end
-
 ---@param level rustaceanvim.rustcir.level
 function M.rustc_unpretty(level)
-  if not has_tree_sitter_rust() then
+  if not rts.has_tree_sitter_rust() then
     vim.notify("a treesitter parser for Rust is required for 'rustc unpretty'", vim.log.levels.ERROR)
     return
   end

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -42,6 +42,7 @@
 --- 'testables {args[]}?' - Run tests
 ---                         ':RustLsp!' means run the last testable (ignores any args).
 ---                         `args[]` allows you to override the executable's arguments.
+--- 'relatedTests'        - Open the tests rust-analyzer associates with the symbol under the cursor.
 --- 'expandMacro' - Expand macros recursively.
 --- 'moveItem {up|down}' - Move items up or down.
 --- 'codeAction' - Sometimes, rust-analyzer groups code actions by category,

--- a/lua/rustaceanvim/treesitter.lua
+++ b/lua/rustaceanvim/treesitter.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+local api = vim.api
+
+---@return boolean
+function M.has_tree_sitter_rust()
+  return #api.nvim_get_runtime_file('parser/rust.so', true) > 0
+    or require('rustaceanvim.shell').is_windows() and #api.nvim_get_runtime_file('parser/rust.dll', true) > 0
+end
+
+-- The `rust-analyzer/relatedTests` resolves using the identifier under the cursor,
+-- but it is useful to resolve related tests while having the cursor in the function body.
+-- This function will recursively search for the parent fn and then descend to find the child
+-- identifier, so that the `relatedTest` method works even if the cursor is inside the
+-- function.
+---@return lsp.Position|nil
+function M.find_fn_identifier_position()
+  local cursor = vim.api.nvim_win_get_cursor(0)
+  local start_pos = { math.max(cursor[1] - 1, 0), cursor[2] }
+
+  local node = vim.treesitter.get_node { pos = start_pos }
+  while node do
+    if node:type() == 'function_item' then
+      for child in node:iter_children() do
+        if child:type() == 'identifier' then
+          local start_row, start_col = child:start()
+          return { line = start_row, character = start_col }
+        end
+      end
+    end
+    node = node:parent()
+  end
+  return nil
+end
+
+return M


### PR DESCRIPTION
This PR addresses #779.

The behavior it implements is like this in the video below:


https://github.com/user-attachments/assets/1edde7f2-2690-45fd-a9a0-df33ceaf0f7c

Summary:

- when there is a single test is jumps to that test immediately
- if there are more than one test returned from the LSP, a picker is shown

Manually Tested:

- navigating to test within the same file
- navigating to test in a separate file
- navigating to test when there is a single related test
