### PR TITLE
fix(lsp): create `RustLsp` commands on each buffer attach

### DIFF
--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -267,7 +267,6 @@ Starting rust-analyzer client in detached/standalone mode (with reduced function
     local old_on_init = lsp_start_config.on_init
     lsp_start_config.on_init = function(...)
       override_apply_text_edits()
-      commands.create_rust_lsp_command(bufnr)
       if type(old_on_init) == 'function' then
         old_on_init(...)
       end
@@ -278,6 +277,10 @@ Starting rust-analyzer client in detached/standalone mode (with reduced function
       if type(old_on_attach) == 'function' then
         old_on_attach(...)
       end
+
+      local _, attach_bufnr = ...
+      commands.create_rust_lsp_command(attach_bufnr)
+
       if config.dap.autoload_configurations then
         -- When switching projects, there might be new debuggables (#466)
         require('rustaceanvim.commands.debuggables').add_dap_debuggables()


### PR DESCRIPTION
I believe this PR fixes a problem introduced in https://github.com/mrcjkb/rustaceanvim/pull/953. I believe it made the command `RustLsp` buffer local, but the method `on_init` is called once when the LSP is started.

I think this caused that only single buffer had the command, and I have bindings to show diagnostics, which resulted in this error:

```
E5108: Error executing lua: /home/lpiepiora/.config/nvim/lua/plugins/rust.lua:44: Command not found: RustLsp
stack traceback:
        [C]: in function 'RustLsp'
        /home/lpiepiora/.config/nvim/lua/plugins/rust.lua:44: in function </home/lpiepiora/.config/nvim/lua/plugins/rust.lua:44>
```

for every buffer, but the first one that I opened.

This PR moves the command creation to `on_attach` callback.