### PR TITLE
fix(lsp): `RustLsp` command not found when reloadimg workspace from `Cargo.toml`

### DIFF
--- a/ftplugin/toml.lua
+++ b/ftplugin/toml.lua
@@ -11,6 +11,7 @@ end
 local config = require('rustaceanvim.config.internal')
 local ra = require('rustaceanvim.rust_analyzer')
 if config.tools.reload_workspace_from_cargo_toml then
+  local reload_workspace = require('rustaceanvim.commands.workspace_refresh')
   local group = vim.api.nvim_create_augroup('RustaceanCargoReloadWorkspace', { clear = false })
   local bufnr = vim.api.nvim_get_current_buf()
   vim.api.nvim_clear_autocmds {
@@ -22,7 +23,7 @@ if config.tools.reload_workspace_from_cargo_toml then
     group = group,
     callback = function()
       if #ra.get_active_rustaceanvim_clients(nil) > 0 then
-        vim.cmd.RustLsp { 'reloadWorkspace', mods = { silent = true } }
+        reload_workspace { silent = true }
       end
     end,
   })

--- a/lua/rustaceanvim/commands/workspace_refresh.lua
+++ b/lua/rustaceanvim/commands/workspace_refresh.lua
@@ -1,17 +1,22 @@
 local M = {}
 
-local function handler(err)
-  if err then
-    vim.notify(tostring(err), vim.log.levels.ERROR)
-    return
-  end
-  vim.notify('Cargo workspace reloaded')
-end
-
 local rl = require('rustaceanvim.rust_analyzer')
 
-function M.reload_workspace()
-  vim.notify('Reloading Cargo Workspace')
+---@param opts? { silent?: boolean }
+function M.reload_workspace(opts)
+  opts = opts or {}
+  local function handler(err)
+    if err then
+      vim.notify(tostring(err), vim.log.levels.ERROR)
+      return
+    end
+    if not opts.silent then
+      vim.notify('Cargo workspace reloaded')
+    end
+  end
+  if not opts.silent then
+    vim.notify('Reloading Cargo Workspace')
+  end
   rl.any_buf_request('rust-analyzer/reloadWorkspace', nil, handler)
 end
 


### PR DESCRIPTION
Hi, I hit an issue:
with `tools.reload_workspace_from_cargo_toml` enabled, saving Cargo.toml triggers `:RustLsp reloadWorkspace`, but `RustLsp` is only created on Rust buffer attach, so the command is missing in the Cargo.toml buffer and save errors with “Command not found: RustLsp”. 

Error detail:
```
Error detected while processing BufWritePost Autocommands for "<buffer=13>":
Error executing lua callback: /home/fys/projects/rustaceanvim/ftplugin/toml.lua:25: Command not found: RustLsp
stack traceback:
        [C]: in function 'RustLsp'
        /home/fys/projects/rustaceanvim/ftplugin/toml.lua:25: in function </home/fys/projects/rustaceanvim/ftplugin/toml.lua:23>
```

Opened this pr, ptal when you have a moment.