### PR TITLE
fix(lsp): don't start client without workspace root if `standalone` is disabled

### DIFF
--- a/lua/rustaceanvim/lsp/init.lua
+++ b/lua/rustaceanvim/lsp/init.lua
@@ -175,6 +175,14 @@ M.start = function(bufnr)
   cargo.get_config_root_dir(client_config, bufname, function(root_dir)
     if not root_dir then
       if not client_config.standalone then
+        vim.notify(
+          [[
+rustaceanvim:
+No project root found.
+Not starting rust-analyzer client because detached/standalone mode is disabled.
+]],
+          vim.log.levels.ERROR
+        )
         return
       end
       vim.notify(


### PR DESCRIPTION
Hi, I hit another issue:
with `standalone = false` is set, lsp start, and use the vim-fugitive to diff code, the following warn is shown:
```
rustaceanvim:
No project root found.
Starting rust-analyzer client in detached/standalone mode (with reduced functionality).
```

After looking through the code, it seems that the [standalone](https://github.com/mrcjkb/rustaceanvim/blob/7469ec39a155120460543a74b55be1f39368aea3/lua/rustaceanvim/config/internal.lua#L303) option is not actually used. Opened this pr, ptal when you have a moment.