### PR TITLE
fix(ui/renderDiagnostics): terminal already connected to buffer

### DIFF
--- a/lua/rustaceanvim/commands/diagnostic.lua
+++ b/lua/rustaceanvim/commands/diagnostic.lua
@@ -254,12 +254,20 @@ local function render_ansi_code_diagnostic(rendered_diagnostic)
         focus_id = 'ra-render-diagnostic',
       })
     )
-    -- Clear content of preview buffer
-    vim.bo[bufnr].modifiable = true
-    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
-    vim.bo[bufnr].modifiable = false
-    -- Send content with ansi color codes to preview buffer
-    local chanid = vim.api.nvim_open_term(bufnr, {})
+
+    -- Send content with ANSI color codes to preview buffer
+    if vim.b[bufnr].chanid == nil then
+      -- Clear content of preview buffer
+      vim.bo[bufnr].modifiable = true
+      vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
+      vim.bo[bufnr].modifiable = false
+
+      vim.b[bufnr].chanid = vim.api.nvim_open_term(bufnr, {})
+    end
+
+    local chanid = vim.b[bufnr].chanid
+    -- reset the terminal to remove previous text
+    vim.api.nvim_chan_send(chanid, '\27c')
     vim.api.nvim_chan_send(chanid, vim.trim('1. Open in split\r\n' .. '---\r\n' .. rendered_diagnostic))
 
     vim.api.nvim_create_autocmd('WinEnter', {


### PR DESCRIPTION
Neovim introduced this fix: https://github.com/neovim/neovim/pull/37219 which prevents terminal to be connected to a buffer more than once.

This change was backported (https://github.com/neovim/neovim/pull/37249) to Neovim 0.11.6, which caused an error about the terminal being already connected.

<img width="1213" height="99" alt="Screenshot 2026-02-01 at 09 52 32" src="https://github.com/user-attachments/assets/1a51e622-e85c-42bf-a75a-23e5b35b87da" />

To reproduce this issue, having the latest Neovim (0.11.6) run the `RustLsp renderDiagnostic current` twice. It renders once, but the second render instead of focusing shows the error and clears the floating window.