### PR TITLE
fix(health): remove JSON config check

### DIFF
--- a/lua/rustaceanvim/health.lua
+++ b/lua/rustaceanvim/health.lua
@@ -164,25 +164,6 @@ local function check_tree_sitter()
   end
 end
 
-local function check_json_config()
-  local json = require('rustaceanvim.config.json')
-  if json.is_json_config_loaded() then
-    local errors = json.get_errors()
-    if #errors > 0 then
-      h.warn('.vscode/settings.json failed to load.')
-      vim.iter(errors):each(h.error)
-      return
-    end
-    local warnings = json.get_warnings()
-    if #warnings == 0 then
-      h.ok('.vscode/settings.json loaded without errors.')
-    else
-      h.warn('.vscode/settings.json loaded with warnings.')
-      vim.iter(warnings):each(h.warn)
-    end
-  end
-end
-
 function health.check()
   local types = require('rustaceanvim.types.internal')
   local config = require('rustaceanvim.config.internal')
@@ -346,7 +327,6 @@ function health.check()
   check_config(config)
   check_for_conflicts()
   check_tree_sitter()
-  check_json_config()
 end
 
 return health


### PR DESCRIPTION
v8.0.0 of rustaceanvim deprecates native support for '.vscode/settings.json' in favor of 'codesettings.nvim'. However, 'health.lua' still includes a 'check_json_config()' health check for the deprecated functionality.

This results in a "false-positive" error when running ':checkhealth rustaceanvim' on v8.0.0.

This PR removes the health check for the deprecated functionality.

As an aside, I'm a novice open-source contributor and open to any feedback, especially if I've handled anything incorrectly/poorly. This just seemed like low-hanging fruit and I wanted to try contributing, rather than raising an issue that someone else would have to deal with.