### PR TITLE
docs: fix various typos in README and vimdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,7 +722,7 @@ by setting the rust-analyzer
   > [!NOTE]
   >
   > This is only useful if you set the option,
-  > `['rust-analzyer'].checkOnSave = false`.
+  > `['rust-analyzer'].checkOnSave = false`.
 
 </details>
 
@@ -937,7 +937,7 @@ nvim -u minimal.lua
 
 > [!IMPORTANT]
 >
-> I strongly recommend against using rust-analyzer managed my mason.nvim,
+> I strongly recommend against using rust-analyzer managed by mason.nvim,
 > as version mismatches between rust-analyzer and your project toolchain
 > can and most likely will lead to subtle issues.
 
@@ -989,7 +989,7 @@ or you may use [`blink.cmp`](https://github.com/saghen/blink.cmp).
 #### I'm having issues with (auto)completion
 
 rustaceanvim doesn't implement (auto)completion.
-Issues with (auto)completion either come from another plugin or rust-analzyer.
+Issues with (auto)completion either come from another plugin or rust-analyzer.
 
 #### mason.nvim and nvim-lspconfig
 

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -58,7 +58,7 @@
 ---
 ---               For example, if you set the keymap: `vim.keymap.set('n', '<space>a', '<Plug>RustHoverAction')`,
 ---               you can invoke the third hover action with `3<space>a`.
---- 'explainError {cycle?|cycle_prev?|current?}' - Display a hover window with explanations form the Rust error index.
+--- 'explainError {cycle?|cycle_prev?|current?}' - Display a hover window with explanations from the Rust error index.
 ---            - If called with |cycle| or no args:
 ---              Like |vim.diagnostic.goto_next|,
 ---              |explainError| will cycle diagnostics,


### PR DESCRIPTION
There are several typos in README and vimdoc, which can be easily fixed and improve the overall reading experience.

- [x] Updated documentation.

# **Description:**
## README

- Changed "managed my mason.nvim" to "managed by mason.nvim" under the Minimal config section.
- Changed "rust-analzyer" to "rust-analyzer" (two instances: one in Fly check, one in FAQ).

## lua/rustaceanvim/init.lua

Changed "form the Rust error index" to "from the Rust error index" in the explainError block.