### PR TITLE
fix: warn if rust-analyzer not found

### DIFF
--- a/lua/rustaceanvim/config/internal.lua
+++ b/lua/rustaceanvim/config/internal.lua
@@ -277,7 +277,11 @@ local RustaceanDefaultConfig = {
       end
       ---@cast cmd string[]
       local rs_bin = cmd[1]
-      return vim.fn.executable(rs_bin) == 1
+      if vim.fn.executable(rs_bin) ~= 1 then
+        vim.notify('Rust Analyzer not found: ' .. rs_bin, vim.log.levels.WARN)
+        return false
+      end
+      return true
     end,
     ---@type string[] | fun():(string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient)
     cmd = function()


### PR DESCRIPTION
Currently, if rustaceanvim can't find a rust analyzer binary, it doesn't work and provides zero feedback why, which a bit annoying to debug.