### PR TITLE
fix(lsp/external_docs): coerce URI userdata to string

### DIFF
--- a/lua/rustaceanvim/commands/external_docs.lua
+++ b/lua/rustaceanvim/commands/external_docs.lua
@@ -12,10 +12,11 @@ function M.open_external_docs()
     vim.lsp.util.make_position_params(0, clients[1].offset_encoding or 'utf-8'),
     function(_, response)
       local url
-      if response['local'] and vim.uv.fs_stat(vim.uri_to_fname(response['local'])) then
-        url = response['local']
+      local local_uri = response['local'] and tostring(response['local'])
+      if local_uri and vim.uv.fs_stat(vim.uri_to_fname(local_uri)) then
+        url = local_uri
       else
-        url = response.web
+        url = response.web and tostring(response.web)
       end
       if url then
         local config = require('rustaceanvim.config.internal')


### PR DESCRIPTION
## Summary

- rust-analyzer's `experimental/externalDocs` response contains `local` and `web` fields typed as `lsp_types::Url`. When deserialized over JSON-RPC into Lua, these arrive as **userdata objects** rather than plain strings.
- Passing them directly to `vim.uri_to_fname()` causes: `attempt to index local 'uri' (a userdata value)`
- This wraps both fields with `tostring()` to ensure they are plain strings before use.

## Steps to reproduce

1. Open a Rust file that has locally generated `cargo doc` output (e.g., a Dioxus project)
2. Run `:RustLsp externalDocs`
3. Error: `vim.uri_to_fname()` receives userdata instead of a string

## Root cause

`response['local']` is `lsp_types::Url` ([rust-analyzer ext.rs](https://github.com/rust-lang/rust-analyzer/blob/master/crates/rust-analyzer/src/lsp/ext.rs)), which Neovim's LSP client deserializes as a userdata object. `vim.uri_to_fname()` expects a plain Lua string.