### PR TITLE
docs(readme): corrected neovim built-in plugin manager code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ that are specific to rust-analyzer.
 ### Using Neovim's built-in plugin manager
 
 ```lua
-vim.pack.add {
+vim.pack.add ({
+  {
   src = 'https://github.com/mrcjkb/rustaceanvim',
   -- To avoid being surprised by breaking changes,
   -- I recommend you set a version range
   version = vim.version.range('^9')
-}
+  }
+})
 ```
 
 ### [`rocks.nvim`](https://github.com/nvim-neorocks/rocks.nvim)


### PR DESCRIPTION
Pasting the original code into init.lua and running Neovim gave this error:

```
Error in /home/username/.config/nvim/init.lua:
E5113: Lua chunk: /usr/share/nvim/runtime/lua/vim/pack.lua:994: specs: expected list, got table: 0x7f7de1c931f0
stack traceback:
        [C]: in function 'error'
        vim/_core/shared.lua: in function 'validate'
        /usr/share/nvim/runtime/lua/vim/pack.lua:994: in function 'add'
        /home/username/.config/nvim/init.lua:1: in main chunk
```
According to the Neovim documentation, extra brackets had to be added.
