### PR TITLE
fix(lsp/runnables): support non-cargo targets

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -15,10 +15,13 @@ if not vim.g.loaded_rustaceanvim then
     local cached_commands = require('rustaceanvim.cached_commands')
     ---@type rustaceanvim.RARunnable[]
     local ra_runnables = command.arguments
-    local runnable = ra_runnables[1]
-    local cargo_args = runnable.args.cargoArgs
-    if #cargo_args > 0 and vim.startswith(cargo_args[1], 'test') then
-      cached_commands.set_last_testable(1, ra_runnables)
+    local runnable = runnables[1]
+    local cargoRunnable = runnables.as_cargo_runnable(runnable)
+    if cargoRunnable then
+      local cargo_args = cargoRunnable.args.cargoArgs
+      if #cargo_args > 0 and vim.startswith(cargo_args[1], 'test') then
+        cached_commands.set_last_testable(1, ra_runnables)
+      end
     end
     cached_commands.set_last_runnable(1, ra_runnables)
     runnables.run_command(1, ra_runnables)
@@ -38,8 +41,14 @@ if not vim.g.loaded_rustaceanvim then
 
   vim.lsp.commands['rust-analyzer.debugSingle'] = function(command)
     local overrides = require('rustaceanvim.overrides')
-    local args = command.arguments[1].args
-    ---@diagnostic disable-next-line: undefined-field
+    local runnables = require('rustaceanvim.runnables')
+    ---@type rustaceanvim.RARunnableArgs
+    local runnable_args = command.arguments[1].args
+    local args = runnables.as_cargo_runnable_args(runnable_args)
+    if not args then
+      vim.notify('Debugging non-cargo runnables is not supported.', vim.log.levels.ERROR)
+      return
+    end
     overrides.sanitize_command_for_debugging(args.cargoArgs)
     local cached_commands = require('rustaceanvim.cached_commands')
     cached_commands.set_last_debuggable(args)

--- a/lua/rustaceanvim/cached_commands.lua
+++ b/lua/rustaceanvim/cached_commands.lua
@@ -4,7 +4,7 @@ local M = {}
 
 ---@class rustaceanvim.CommandCache
 local cache = {
-  ---@type rustaceanvim.RARunnableArgs | nil
+  ---@type rustaceanvim.RACargoRunnableArgs | nil
   last_debuggable = nil,
   ---@type rustaceanvim.RARunnablesChoice
   last_runnable = nil,
@@ -30,7 +30,7 @@ M.set_last_testable = function(choice, runnables)
   }
 end
 
----@param args rustaceanvim.RARunnableArgs
+---@param args rustaceanvim.RACargoRunnableArgs
 M.set_last_debuggable = function(args)
   cache.last_debuggable = args
 end
@@ -54,8 +54,13 @@ end
 ---@param choice rustaceanvim.RARunnablesChoice
 ---@param executableArgsOverride? string[]
 local function override_executable_args_if_set(choice, executableArgsOverride)
+  local runnables = require('rustaceanvim.runnables')
   if type(executableArgsOverride) == 'table' and #executableArgsOverride > 0 then
-    choice.runnables[choice.choice].args.executableArgs = executableArgsOverride
+    local runnable = choice.runnables[choice.choice]
+    local cargoRunnable = runnables.as_cargo_runnable(runnable)
+    if cargoRunnable then
+      cargoRunnable.args.executableArgs = executableArgsOverride
+    end
   end
 end
 

--- a/lua/rustaceanvim/commands/debuggables.lua
+++ b/lua/rustaceanvim/commands/debuggables.lua
@@ -14,7 +14,7 @@ end
 ---@type { [string]: boolean? } Used to prevent this plugin from adding the same configuration twice
 local _dap_configuration_added = {}
 
----@param args rustaceanvim.RARunnableArgs
+---@param args rustaceanvim.RACargoRunnableArgs
 ---@return string
 local function build_label(args)
   local ret = ''
@@ -35,7 +35,7 @@ local function build_label(args)
   return ret
 end
 
----@param result rustaceanvim.RARunnable[]
+---@param result rustaceanvim.RACargoRunnable[]
 ---@return string[] option_strings
 local function get_options(result)
   ---@type string[]
@@ -53,10 +53,10 @@ local function get_options(result)
   return option_strings
 end
 
----@param args rustaceanvim.RARunnableArgs
+---@param args rustaceanvim.RACargoRunnableArgs
 ---@return boolean
 local function is_valid_test(args)
-  local is_not_cargo_check = args.cargoArgs[1] ~= 'check'
+  local is_not_cargo_check = args.cargoArgs and args.cargoArgs[1] ~= 'check'
   return is_not_cargo_check
 end
 
@@ -67,11 +67,13 @@ end
 -- debugging friendly. For example, we move cargo run to cargo build, and cargo
 -- test to cargo test --no-run.
 ---@param result rustaceanvim.RARunnable[]
+---@return rustaceanvim.RACargoRunnable[]
 local function sanitize_results_for_debugging(result)
-  ---@type rustaceanvim.RARunnable[]
-  local ret = vim.tbl_filter(function(value)
-    ---@cast value rustaceanvim.RARunnable
-    return is_valid_test(value.args)
+  ---@type rustaceanvim.RACargoRunnable[]
+  local ret = vim.tbl_filter(function(runnable)
+    ---@cast runnable rustaceanvim.RARunnable
+    local cargoRunnable = ra_runnables.as_cargo_runnable(runnable)
+    return cargoRunnable ~= nil and is_valid_test(cargoRunnable.args)
   end, result or {})
 
   local overrides = require('rustaceanvim.overrides')
@@ -82,6 +84,7 @@ local function sanitize_results_for_debugging(result)
   return ret
 end
 
+---@param args rustaceanvim.RACargoRunnableArgs
 local function dap_run(args)
   local rt_dap = require('rustaceanvim.dap')
   local ok, dap = pcall(require, 'dap')
@@ -96,7 +99,7 @@ local function dap_run(args)
   end
 end
 
----@param debuggables rustaceanvim.RARunnable[]
+---@param debuggables rustaceanvim.RACargoRunnable[]
 ---@param executableArgsOverride? string[]
 local function ui_select_debuggable(debuggables, executableArgsOverride)
   debuggables = ra_runnables.apply_exec_args_override(executableArgsOverride, debuggables)
@@ -113,7 +116,7 @@ local function ui_select_debuggable(debuggables, executableArgsOverride)
   end)
 end
 
----@param debuggables rustaceanvim.RARunnable[]
+---@param debuggables rustaceanvim.RACargoRunnable[]
 local function add_debuggables_to_nvim_dap(debuggables)
   local ok, dap = pcall(require, 'dap')
   if not ok then
@@ -146,12 +149,13 @@ local function add_debuggables_to_nvim_dap(debuggables)
   pcall(go) -- Ignore stack overflow errors
 end
 
----@param debuggables rustaceanvim.RARunnable[]
+---@param debuggables rustaceanvim.RACargoRunnable[]
 ---@param executableArgsOverride? string[]
 local function debug_at_cursor_position(debuggables, executableArgsOverride)
   if debuggables == nil then
     return
   end
+  ---@type rustaceanvim.RACargoRunnable[]
   debuggables = ra_runnables.apply_exec_args_override(executableArgsOverride, debuggables)
   local choice = ra_runnables.get_runnable_at_cursor_position(debuggables)
   if not choice then
@@ -162,7 +166,7 @@ local function debug_at_cursor_position(debuggables, executableArgsOverride)
   dap_run(args)
 end
 
----@param callback fun(result:rustaceanvim.RARunnable[])
+---@param callback fun(result:rustaceanvim.RACargoRunnable[])
 local function mk_handler(callback)
   return function(_, result, _, _)
     ---@cast result rustaceanvim.RARunnable[]

--- a/lua/rustaceanvim/dap.lua
+++ b/lua/rustaceanvim/dap.lua
@@ -252,7 +252,7 @@ local function pall_with_warn(action, desc)
 end
 
 ---@param adapter rustaceanvim.dap.executable.Config | rustaceanvim.dap.server.Config
----@param args rustaceanvim.RARunnableArgs
+---@param args rustaceanvim.RACargoRunnableArgs
 ---@param verbose? boolean
 local function handle_configured_options(adapter, args, verbose)
   local is_generate_source_map_enabled = types.evaluate(config.dap.auto_generate_source_map)
@@ -281,7 +281,7 @@ local function handle_configured_options(adapter, args, verbose)
 end
 
 ---@package
----@param args rustaceanvim.RARunnableArgs
+---@param args rustaceanvim.RACargoRunnableArgs
 ---@param verbose? boolean
 ---@param callback? fun(config: rustaceanvim.dap.client.Config)
 ---@param on_error? fun(err: string)

--- a/lua/rustaceanvim/neotest/init.lua
+++ b/lua/rustaceanvim/neotest/init.lua
@@ -275,7 +275,9 @@ function NeotestAdapter.build_spec(run_args)
   if not runnable then
     return
   end
-  local exe, args, cwd, env = require('rustaceanvim.runnables').get_command(runnable)
+  local runnables = require('rustaceanvim.runnables')
+  local cargoRunnable = runnables.as_cargo_runnable(runnable)
+  local exe, args, cwd, env = runnables.get_command(runnable)
   local context = {
     file = pos.path,
     pos_id = pos.id,
@@ -285,11 +287,14 @@ function NeotestAdapter.build_spec(run_args)
     is_cargo_test = args[1] == 'test',
   }
   if run_args.strategy == 'dap' then
+    if not cargoRunnable then
+      return
+    end
     local dap = require('rustaceanvim.dap')
-    overrides.sanitize_command_for_debugging(runnable.args.cargoArgs)
+    overrides.sanitize_command_for_debugging(cargoRunnable.args.cargoArgs)
     local future = nio.control.future()
     ---@diagnostic disable-next-line: invisible
-    dap.start(runnable.args, false, function(strategy)
+    dap.start(cargoRunnable.args, false, function(strategy)
       future.set(strategy)
     end, function(err)
       future.set_error(err)
@@ -314,8 +319,8 @@ function NeotestAdapter.build_spec(run_args)
       }
     end
     return run_spec
-  else
-    overrides.undo_debug_sanitize(runnable.args.cargoArgs)
+  elseif cargoRunnable then
+    overrides.undo_debug_sanitize(cargoRunnable.args.cargoArgs)
   end
   local insert_pos = context.is_cargo_test and 2 or 3
   table.insert(args, insert_pos, '--no-fail-fast')

--- a/lua/rustaceanvim/neotest/trans.lua
+++ b/lua/rustaceanvim/neotest/trans.lua
@@ -3,8 +3,17 @@ local M = {}
 ---@param runnable rustaceanvim.RARunnable
 ---@return string | nil
 local function get_test_path(runnable)
-  local executableArgs = runnable.args and runnable.args.executableArgs or {}
-  return #executableArgs > 0 and executableArgs[1] or nil
+  local runnables = require('rustaceanvim.runnables')
+  local shellRunnable = runnables.as_shell_runnable(runnable)
+  if shellRunnable then
+    local shellArgs = shellRunnable.args and shellRunnable.args.args or {}
+    return #shellArgs > 0 and shellArgs[#shellArgs] or nil
+  end
+  local cargoRunnable = runnables.as_cargo_runnable(runnable)
+  if cargoRunnable then
+    local executableArgs = cargoRunnable.args and cargoRunnable.args.executableArgs or {}
+    return #executableArgs > 0 and executableArgs[1] or nil
+  end
 end
 
 ---@overload fun(file_path: string, test_path: string | nil)
@@ -23,20 +32,25 @@ end
 ---@param runnable rustaceanvim.RARunnable
 ---@return rustaceanvim.neotest.Position | nil
 function M.runnable_to_position(file_path, runnable)
-  local cargoArgs = runnable.args and runnable.args.cargoArgs or {}
+  local runnables = require('rustaceanvim.runnables')
+  local cargoRunnable = runnables.as_cargo_runnable(runnable)
+  if not cargoRunnable then
+    return nil
+  end
+  local cargoArgs = cargoRunnable.args and cargoRunnable.args.cargoArgs or {}
   if #cargoArgs > 0 and vim.startswith(cargoArgs[1], 'test') then
     ---@type neotest.PositionType
     local type
-    if vim.startswith(runnable.label, 'cargo test -p') then
+    if vim.startswith(cargoRunnable.label, 'cargo test -p') then
       type = 'dir'
-    elseif vim.startswith(runnable.label, 'test-mod') then
+    elseif vim.startswith(cargoRunnable.label, 'test-mod') then
       type = 'namespace'
-    elseif vim.startswith(runnable.label, 'test') or vim.startswith(runnable.label, 'doctest') then
+    elseif vim.startswith(cargoRunnable.label, 'test') or vim.startswith(cargoRunnable.label, 'doctest') then
       type = 'test'
     else
       return
     end
-    local location = runnable.location
+    local location = cargoRunnable.location
     local start_row, start_col, end_row, end_col = 0, 0, 0, 0
     if location then
       start_row = location.targetRange.start.line + 1
@@ -55,7 +69,7 @@ function M.runnable_to_position(file_path, runnable)
     ---@type rustaceanvim.neotest.Position
     local pos = {
       id = M.get_position_id(file_path, runnable),
-      name = test_path or runnable.label,
+      name = test_path or cargoRunnable.label,
       type = type,
       path = file_path,
       range = { start_row, start_col, end_row, end_col },

--- a/lua/rustaceanvim/runnables.lua
+++ b/lua/rustaceanvim/runnables.lua
@@ -137,8 +137,21 @@ end
 ---@return string | nil dir
 ---@return table<string, string> | nil env
 function M.get_command(runnable)
-  local args = runnable.args
+  local shellRunnable = M.as_shell_runnable(runnable)
+  if shellRunnable then
+    local args = shellRunnable.args
+    return args.program, args.args or {}, args.cwd, args.environment
+  end
+  local cargoRunnable = M.as_cargo_runnable(runnable)
+  if not cargoRunnable then
+    error(
+      'Unsupported runnable type: '
+        .. (runnable.kind or '<unspecified>')
+        .. '. Only cargo and shell runnables are supported.'
+    )
+  end
 
+  local args = cargoRunnable.args
   local dir = args.workspaceRoot
   local env = args.environment
 
@@ -198,7 +211,11 @@ end
 ---@return boolean
 local function is_testable(runnable)
   ---@cast runnable rustaceanvim.RARunnable
-  local cargoArgs = runnable.args and runnable.args.cargoArgs or {}
+  local cargoRunnable = M.as_cargo_runnable(runnable)
+  if not cargoRunnable then
+    return false
+  end
+  local cargoArgs = cargoRunnable.args.cargoArgs
   return #cargoArgs > 0 and vim.startswith(cargoArgs[1], 'test')
 end
 
@@ -209,18 +226,23 @@ function M.apply_exec_args_override(executableArgsOverride, runnables)
   if type(executableArgsOverride) == 'table' and #executableArgsOverride > 0 then
     local unique_runnables = {}
     for _, runnable in pairs(runnables) do
-      local args = runnable.args.executableArgs
-      local override_args = {}
-      if #args > 0 and not vim.startswith(args[1], '--') then
-        -- This is a target arg. We want to keep it.
-        override_args = { args[1] }
-        if #args > 1 and args[2] == '--exact' then
-          -- We're matching the target exactly. We should keep this.
-          table.insert(override_args, args[2])
+      local cargoRunnable = M.as_cargo_runnable(runnable)
+      if not cargoRunnable then
+        unique_runnables[vim.inspect(runnable)] = runnable
+      else
+        local args = cargoRunnable.args.executableArgs
+        local override_args = {}
+        if #args > 0 and not vim.startswith(args[1], '--') then
+          -- This is a target arg. We want to keep it.
+          override_args = { args[1] }
+          if #args > 1 and args[2] == '--exact' then
+            -- We're matching the target exactly. We should keep this.
+            table.insert(override_args, args[2])
+          end
         end
+        cargoRunnable.args.executableArgs = vim.list_extend(override_args, executableArgsOverride)
+        unique_runnables[vim.inspect(cargoRunnable)] = cargoRunnable
       end
-      runnable.args.executableArgs = vim.list_extend(override_args, executableArgsOverride)
-      unique_runnables[vim.inspect(runnable)] = runnable
     end
     runnables = vim.tbl_values(unique_runnables)
   end

--- a/lua/rustaceanvim/runnables.lua
+++ b/lua/rustaceanvim/runnables.lua
@@ -12,21 +12,86 @@ local function get_params()
   }
 end
 
+---This mirrors the [typescript definitions in rust-analyzer][ra]
+---
+---[ra]: https://github.com/rust-lang/rust-analyzer/blob/0dc46bfea9b17fed93ab57393971fb932e7a5dd4/editors/code/src/lsp_ext.ts#L232-L283
+---
+---Beware, Lua tooling does not do type narrowing well, and blindly merges all
+---fields in the types for `.args`. You must provide runtime checks of
+---runnable.kind. There are convenience functions `as_cargo_runnable` and
+---`as_shell_runnable` that perform these checks and casts for you.
+---
 ---@class rustaceanvim.RARunnable
----@field args rustaceanvim.RARunnableArgs
 ---@field label string
 ---@field location? rustaceanvim.RARunnableLocation
+---RA has had both cargo and shell runnables since 2024 (rust ~1.80). But it only
+---started providing `kind: "cargo" | "shell"` in 2026. Before then it used
+---serde(untagged) on the args enum. So it is safer not to rely on this field for
+---now and presume it might be missing. Prefer checking presence of cargoArgs.
+---@field kind? "cargo" | "shell"
+---@field args {}
+
+---@class rustaceanvim.RACargoRunnable
+---@field kind? '"cargo"'
+---@field label string
+---@field location? rustaceanvim.RARunnableLocation
+---@field args rustaceanvim.RACargoRunnableArgs
+
+---@class rustaceanvim.RAShellRunnable
+---@field kind? '"shell"'
+---@field label string
+---@field location? rustaceanvim.RARunnableLocation
+---@field args rustaceanvim.RAShellRunnableArgs
 
 ---@class rustaceanvim.RARunnableLocation
 ---@field targetRange lsp.Range
 ---@field targetSelectionRange lsp.Range
 
----@class rustaceanvim.RARunnableArgs
+---@class rustaceanvim.RACargoRunnableArgs
+---@field cwd string
+---@field environment? table<string, string>
 ---@field workspaceRoot string
 ---@field cargoArgs string[]
 ---@field cargoExtraArgs? string[]
 ---@field executableArgs string[]
+---@field overrideCargo? string
+
+---@class rustaceanvim.RAShellRunnableArgs
+---@field cwd string
 ---@field environment? table<string, string>
+---@field program string
+---@field args string[]
+
+---A union (read: merged fields) of the two runnable args types.
+---@alias rustaceanvim.RARunnableArgs rustaceanvim.RACargoRunnableArgs | rustaceanvim.RAShellRunnableArgs
+
+---@param runnable rustaceanvim.RARunnable
+---@return rustaceanvim.RACargoRunnable | nil
+function M.as_cargo_runnable(runnable)
+  ---@type rustaceanvim.RARunnableArgs
+  local args = runnable.args
+  if args and args.cargoArgs then
+    return runnable --[[@as rustaceanvim.RACargoRunnable]]
+  end
+end
+
+---@param runnable_args rustaceanvim.RARunnableArgs
+---@return rustaceanvim.RACargoRunnableArgs | nil
+function M.as_cargo_runnable_args(runnable_args)
+  if runnable_args and runnable_args.cargoArgs then
+    return runnable_args --[[@as rustaceanvim.RACargoRunnableArgs]]
+  end
+end
+
+---@param runnable rustaceanvim.RARunnable
+---@return rustaceanvim.RAShellRunnable | nil
+function M.as_shell_runnable(runnable)
+  ---@type rustaceanvim.RARunnableArgs
+  local args = runnable.args
+  if args and not args.cargoArgs then
+    return runnable --[[@as rustaceanvim.RAShellRunnable]]
+  end
+end
 
 ---@param option string
 ---@return string


### PR DESCRIPTION
I use rustaceanvim without cargo. All the runnables that RA sends have `runnable.kind == "shell"`, which does not have `cargoArgs` to read. So rustaceanvim panics all over the place trying and failing to read `cargoArgs`. Basically every time you open a file. This fixes that.

~~This is just a quick audit of all of the places we read cargoArgs, with a check inserted beforehand. I'm not particularly attached to any of it, but for the time being we can't do much better especially with debuggables where we don't have cargo args to interpret and do run->build conversions etc. Please let me know if I'm using vim.notify wrong or something.~~

This PR turned into a much more type safe runnable usage where `args` is just a table with no fields until you cast it via one of the methods `as_cargo_runnable` or `as_shell_runnable`. So that worked out to be a lot more comprehensive.

Relevant links to RA half of this:

- [`Runnable` and `ShellRunnableArgs` type defs](https://github.com/rust-lang/rust-analyzer/blob/0dc46bfea9b17fed93ab57393971fb932e7a5dd4/editors/code/src/lsp_ext.ts#L232-L283) which I have replicated in lua and linked in a docstring
- https://github.com/rust-lang/rust-analyzer/pull/21424 is fairly illustrative of how these runnables are produced end-to-end -- a rust-project.json runnable template rendered on the fly for a client request.
- https://github.com/rust-lang/rust-analyzer/pull/21423 includes an example rust-project.json that uses runnable templates

Testing:

- I tried with a buck2 + rust-project project. It didn't yell at me. Success!
- For real tests... it would be very nice to have some facility for integration testing this. Maybe to have a rust-project.json, boot up RA and call some predefined LSP methods on it with an nvim client. But I didn't build one.
- Still seems to work on cargo projects, I can run some runnables at least.