### PR TITLE
fix(lsp/commands): `attempt to index local 'runnable'` error

### DIFF
--- a/ftplugin/rust.lua
+++ b/ftplugin/rust.lua
@@ -15,7 +15,7 @@ if not vim.g.loaded_rustaceanvim then
     local cached_commands = require('rustaceanvim.cached_commands')
     ---@type rustaceanvim.RARunnable[]
     local ra_runnables = command.arguments
-    local runnable = runnables[1]
+    local runnable = ra_runnables[1]
     local cargoRunnable = runnables.as_cargo_runnable(runnable)
     if cargoRunnable then
       local cargo_args = cargoRunnable.args.cargoArgs


### PR DESCRIPTION
## Overview 

* Prior, was attempting to index into the *module* `runnables` instead of the array `ra_runnables`.
* This would cause:

  ```
  vim.schedule callback: ...re/nvim/lazy/rustaceanvim/lua/rustaceanvim/runnables.lua:72: attempt
   to index local 'runnable' (a nil value)
  stack traceback:
          ...re/nvim/lazy/rustaceanvim/lua/rustaceanvim/runnables.lua:72: in function 'as_cargo_runnable'
          ...pe/.local/share/nvim/lazy/rustaceanvim/ftplugin/rust.lua:19: in function 'fn'
          ...re/bob/v0.12.0/share/nvim/runtime/lua/vim/lsp/client.lua:1074: in function 'exec_cmd'
          .../bob/v0.12.0/share/nvim/runtime/lua/vim/lsp/codelens.lua:421: in function 'on_choice'
          ...share/nvim/lazy/snacks.nvim/lua/snacks/picker/select.lua:59: in function <...share/
  nvim/lazy/snacks.nvim/lua/snacks/picker/select.lua:58>
  ```
  
### Testing

* I had noticed this when using the Neovim 0.12 builtin `grx` mapping to try and run unit tests in my `mod tests`.
* To test/ reproduce:
  1. Open a Rust project with a unit test module, e.g. `mod tests`. 
  2. On Nvim 0.12, try `grx` on a `#[test]` `fn`.