### PR TITLE
feat(ui/expandMacro): support window layout argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,13 @@ vim.keymap.set(
   </summary>
 
   ```vim
-  :RustLsp expandMacro
+  :RustLsp expandMacro {float?|horizontal?|vertical?}
   ```
   ```lua
   vim.cmd.RustLsp('expandMacro')
+  vim.cmd.RustLsp({ 'expandMacro', 'float' })
   ```
+  The default is `vertical` when no argument is provided.
   ![](https://github.com/mrcjkb/rustaceanvim/assets/12857160/477d9e58-74b0-42ff-87ca-2fef34d06db3)
 </details>
 

--- a/doc/rustaceanvim.txt
+++ b/doc/rustaceanvim.txt
@@ -50,7 +50,7 @@ It accepts the following subcommands:
                          ':RustLsp!' means run the last testable (ignores any args).
                          `args[]` allows you to override the executable's arguments.
  'relatedTests'        - Open the tests rust-analyzer associates with the symbol under the cursor.
- 'expandMacro' - Expand macros recursively.
+ 'expandMacro {float?|horizontal?|vertical?}' - Expand macros recursively.
  'moveItem {up|down}' - Move items up or down.
  'codeAction' - Sometimes, rust-analyzer groups code actions by category,
                 which is not supported by Neovim's built-in |vim.lsp.buf.codeAction|.

--- a/lua/rustaceanvim/commands/expand_macro.lua
+++ b/lua/rustaceanvim/commands/expand_macro.lua
@@ -1,3 +1,4 @@
+local config = require('rustaceanvim.config.internal')
 local ui = require('rustaceanvim.ui')
 
 local M = {}
@@ -37,15 +38,9 @@ local function parse_lines(result)
   return ret
 end
 
----@param result? rustaceanvim.RAMacroExpansionResult
-local function handler(_, result)
-  -- echo a message when result is nil (meaning no macro under cursor) and
-  -- exit
-  if result == nil then
-    vim.notify('No macro under cursor!', vim.log.levels.INFO)
-    return
-  end
-
+---@param lines string[]
+---@param direction 'horizontal' | 'vertical'
+local function render_split(lines, direction)
   -- check if a buffer with the latest id is already open, if it is then
   -- delete it and continue
   ui.delete_buf(latest_buf_id)
@@ -53,27 +48,82 @@ local function handler(_, result)
   -- create a new buffer
   latest_buf_id = vim.api.nvim_create_buf(false, true) -- not listed and scratch
 
-  -- split the window to create a new buffer and set it to our window
-  ui.split(true, latest_buf_id)
+  local vertical = direction == 'vertical'
+  ui.split(vertical, latest_buf_id)
 
   -- set filetype to rust for syntax highlighting
   vim.bo[latest_buf_id].filetype = 'rust'
   -- write the expansion content to the buffer
-  vim.api.nvim_buf_set_lines(latest_buf_id, 0, 0, false, parse_lines(result))
+  vim.api.nvim_buf_set_lines(latest_buf_id, 0, 0, false, lines)
 
   -- make the new buffer smaller
-  ui.resize(true, '-25')
+  ui.resize(vertical, vertical and '-25' or '-5')
+end
+
+---@param lines string[]
+local function render_float(lines)
+  local preview_lines = vim.deepcopy(lines)
+  table.insert(preview_lines, 1, '---')
+  table.insert(preview_lines, 1, '1. Open in split')
+
+  local bufnr, winnr = vim.lsp.util.open_floating_preview(
+    preview_lines,
+    'rust',
+    vim.tbl_extend('keep', config.tools.float_win_config, {
+      focus_id = 'ra-expand-macro',
+    })
+  )
+
+  local function close_float()
+    ui.close_win(winnr)
+  end
+
+  vim.keymap.set('n', 'q', close_float, { buffer = bufnr, noremap = true, silent = true })
+  vim.keymap.set('n', '<Esc>', close_float, { buffer = bufnr, noremap = true, silent = true })
+  vim.keymap.set('n', '<CR>', function()
+    local line = vim.api.nvim_win_get_cursor(winnr)[1]
+    if line > 1 then
+      return
+    end
+    close_float()
+    render_split(lines, 'vertical')
+  end, { buffer = bufnr, noremap = true, silent = true })
+
+  if config.tools.float_win_config.auto_focus then
+    vim.api.nvim_set_current_win(winnr)
+  end
+end
+
+---@param open 'float' | 'horizontal' | 'vertical'
+---@return lsp.Handler
+local function make_handler(open)
+  return function(_, result)
+    if result == nil then
+      vim.notify('No macro under cursor!', vim.log.levels.INFO)
+      return
+    end
+
+    local lines = parse_lines(result)
+    if open == 'float' then
+      render_float(lines)
+    elseif open == 'horizontal' then
+      render_split(lines, 'horizontal')
+    elseif open == 'vertical' then
+      render_split(lines, 'vertical')
+    end
+  end
 end
 
 --- Sends the request to rust-analyzer to expand the macro under the cursor
-function M.expand_macro()
+---@param open 'float' | 'horizontal' | 'vertical'
+function M.expand_macro(open)
   local ra = require('rustaceanvim.rust_analyzer')
   local clients = ra.get_active_rustaceanvim_clients(0)
   if #clients == 0 then
     return
   end
   local params = vim.lsp.util.make_position_params(0, clients[1].offset_encoding or 'utf-8')
-  ra.buf_request(0, 'rust-analyzer/expandMacro', params, handler)
+  ra.buf_request(0, 'rust-analyzer/expandMacro', params, make_handler(open))
 end
 
 return M.expand_macro

--- a/lua/rustaceanvim/commands/init.lua
+++ b/lua/rustaceanvim/commands/init.lua
@@ -60,8 +60,19 @@ local rustlsp_command_tbl = {
     bang = true,
   },
   expandMacro = {
-    impl = function(_)
-      require('rustaceanvim.commands.expand_macro')()
+    impl = function(args)
+      local open = args[1] or 'vertical'
+      if vim.tbl_contains({ 'float', 'horizontal', 'vertical' }, open) then
+        require('rustaceanvim.commands.expand_macro')(open)
+      else
+        vim.notify(
+          'expandMacro: unexpected argument: ' .. vim.inspect(args) .. " expected 'float', 'horizontal', or 'vertical'",
+          vim.log.levels.ERROR
+        )
+      end
+    end,
+    complete = function()
+      return { 'float', 'horizontal', 'vertical' }
     end,
   },
   explainError = {

--- a/lua/rustaceanvim/init.lua
+++ b/lua/rustaceanvim/init.lua
@@ -43,7 +43,7 @@
 ---                         ':RustLsp!' means run the last testable (ignores any args).
 ---                         `args[]` allows you to override the executable's arguments.
 --- 'relatedTests'        - Open the tests rust-analyzer associates with the symbol under the cursor.
---- 'expandMacro' - Expand macros recursively.
+--- 'expandMacro {float?|horizontal?|vertical?}' - Expand macros recursively.
 --- 'moveItem {up|down}' - Move items up or down.
 --- 'codeAction' - Sometimes, rust-analyzer groups code actions by category,
 ---                which is not supported by Neovim's built-in |vim.lsp.buf.codeAction|.


### PR DESCRIPTION
Adds an optional layout argument to the `expandMacro` subcommand:

```vim
:RustLsp expandMacro [float|horizontal|vertical]
```

The default remains `vertical` to preserve the existing behavior.

Floating macro expansions can be closed with `q` or `<Esc>`. Pressing `<CR>` on the first line opens the expansion in a vertical split.


Closes #1108


<!-- Please check what applies. -->

- [x] Fits [CONTRIBUTING.md].
- [x] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/mrcjkb/rustaceanvim/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/mrcjkb/rustaceanvim/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
