### PR TITLE
feat(lsp): only notify once per client on bad server health

### DIFF
--- a/lua/rustaceanvim/server_status.lua
+++ b/lua/rustaceanvim/server_status.lua
@@ -30,14 +30,16 @@ function M.handler(_, result, ctx, _)
   end
   -- notify of LSP errors/warnings
   if is_notify_enabled_for(result.health) then
+    -- only shows client if its not the default one (id 1)
+    local client_str = ctx.client_id == 1 and '' or ' (client ' .. ctx.client_id .. ')'
     local message = ([[
-rust-analyzer health status is [%s]:
+rust-analyzer%s health status is [%s]:
 %s
 Run ':RustLsp logFile' for details.
 To configure or disable rust-analyzer server status notifications,
 see ':h rustaceanvim.lsp.ClientOpts'.
-]]):format(result.health, result.message or '[unknown error]')
-    vim.notify(message, vim.log.levels.WARN)
+]]):format(client_str, result.health, result.message or '[unknown error]')
+    vim.notify_once(message, vim.log.levels.WARN)
   end
   -- deduplicate messages.
   if _ran_once[ctx.client_id] then


### PR DESCRIPTION
About the behavior in #1114, this notifies once when opening a standalone file and never again in such session, I'd consider it solves that good enough.

- [X] Fits [CONTRIBUTING.md].
- [X] Fits [No LLM / No AI Policy].

[CONTRIBUTING.md]: https://github.com/mrcjkb/rustaceanvim/blob/main/CONTRIBUTING.md
[No LLM / No AI Policy]: https://github.com/mrcjkb/rustaceanvim/blob/main/CONTRIBUTING.md#strict-no-llm--no-ai-policy
